### PR TITLE
Provide default for init-action uri

### DIFF
--- a/spydra/pom.xml
+++ b/spydra/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>spydra</artifactId>
 
   <properties>
-    <init-action-uri/>
+    <init-action-uri>spydra-init-actions</init-action-uri>
     <versioned-init-action-uri>${init-action-uri}/${project.version}</versioned-init-action-uri>
     <test-configuration-folder>/Users/steffeng/spydra-conf/</test-configuration-folder>
   </properties>


### PR DESCRIPTION
Makes maven build work with a sane default if it is not specified elsewhere.