### PR TITLE
Fixing PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
   - source $HOME/google-cloud-sdk/path.bash.inc
   - gcloud version
-  - gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS; fi
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ install: true
 
 script:
   # Run on pull requests (encrypted data not available for pull requests)
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn clean test -P !build-extras -Dmaven.javadoc.skip=true -Dinit-action-uri=gs://${INIT_ACTIONS_BUCKET}/spydra -Dtest-configuration-dir=${INTEGRATION_TEST_CONFIG_DIR}; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn clean test -P !release -Dmaven.javadoc.skip=true -Dinit-action-uri=gs://${INIT_ACTIONS_BUCKET}/spydra -Dtest-configuration-dir=${INTEGRATION_TEST_CONFIG_DIR}; fi'
   # Run on merges to master
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn deploy -P sign,build-extras --settings=${CONFIG_DIR}/settings.xml -Dinit-action-uri=gs://${INIT_ACTIONS_BUCKET}/spydra -Dtest-configuration-dir=${INTEGRATION_TEST_CONFIG_DIR}; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn deploy -P release --settings=${CONFIG_DIR}/settings.xml -Dinit-action-uri=gs://${INIT_ACTIONS_BUCKET}/spydra -Dtest-configuration-dir=${INTEGRATION_TEST_CONFIG_DIR}; fi'
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
 
 before_install:
   # Decrypt the secrets (only non pull-requests)
-  - openssl aes-256-cbc -K $encrypted_44004b20f94b_key -iv $encrypted_44004b20f94b_iv -in ${CONFIG_DIR}/secrets.tar.enc -out ${CONFIG_DIR}/secrets.tar -d
-  - tar xvf ${CONFIG_DIR}/secrets.tar --directory ${CONFIG_DIR}
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_44004b20f94b_key -iv $encrypted_44004b20f94b_iv -in ${CONFIG_DIR}/secrets.tar.enc -out ${CONFIG_DIR}/secrets.tar -d; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then tar xvf ${CONFIG_DIR}/secrets.tar --directory ${CONFIG_DIR}; fi
   # Import the FOSS signing key
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then gpg --fast-import ${CONFIG_DIR}/spydra_sign_keys; fi
   # The integration test configuration must be in absolute path, thus using mktemp

--- a/pom.xml
+++ b/pom.xml
@@ -329,18 +329,6 @@
           </plugin>
 
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.3</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-
-          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -358,18 +358,6 @@
           </plugin>
 
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.7</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-
-          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-release-plugin</artifactId>
             <version>2.5.3</version>


### PR DESCRIPTION
* Extract secrets only for non-PRs
* Remove obsolete plugin, as we are using maven-release-plugin (see http://www.sonatype.org/nexus/2015/06/02/how-to-publish-software-artifacts-to-maven-central/)
* Using single release profile instead of separate profiles from old config