### PR TITLE
Add zone metric for create cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,11 +354,7 @@ it during the maven invocation.
 ```json
 {
   "log_bucket": "YOUR_GCS_LOG_BUCKET",
-  "cluster": {
-    "options": {
-      "zone": "europe-west1-d"
-    }
-  }
+  "region": "europe-west1"
 }
 ```
 

--- a/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
+++ b/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
@@ -51,14 +51,18 @@ public class DataprocAPI {
 
   public Optional<Cluster> createCluster(SpydraArgument arguments) throws IOException {
     boolean success = false;
+    String zoneUri = null;
     try {
       Optional<Cluster> cluster = gcloud.createCluster(arguments.getCluster().getName(),
           arguments.getRegion(),
           arguments.getCluster().getOptions());
       success = cluster.isPresent();
+      if (success) {
+        zoneUri = cluster.get().config.gceClusterConfig.zoneUri;
+      }
       return cluster;
     } finally {
-      metrics.clusterCreation(arguments, success);
+      metrics.clusterCreation(arguments, zoneUri, success);
     }
   }
 

--- a/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
+++ b/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
@@ -56,9 +56,9 @@ public class SpydraArgumentUtil {
       throws IOException, URISyntaxException {
 
     SpydraArgument configuration = loadArguments(BASE_CONFIGURATION_FILE_NAME);
-    boolean hasConfigurationInClasspath = configurationExists(SPYDRA_CONFIGURATION_FILE_NAME);
-    LOGGER.debug("Spydra configuration found in classpath?: {}", hasConfigurationInClasspath);
-    if (hasConfigurationInClasspath) {
+
+    if (configurationExists(SPYDRA_CONFIGURATION_FILE_NAME)) {
+      LOGGER.debug("Merge conf found from classpath: {}", SPYDRA_CONFIGURATION_FILE_NAME);
       configuration =
           SpydraArgument.merge(configuration, loadArguments(SPYDRA_CONFIGURATION_FILE_NAME));
     }
@@ -66,10 +66,12 @@ public class SpydraArgumentUtil {
     SpydraArgument mergedForChecking = SpydraArgument.merge(configuration, arguments);
     if (!mergedForChecking.getCluster().name.isPresent()
         && mergedForChecking.getClusterType() == DATAPROC) {
-      SpydraArgument defaultDataprocConfiguration = loadArguments(DEFAULT_DATAPROC_ARGUMENT_FILE_NAME);
-      configuration = SpydraArgument.merge(configuration, defaultDataprocConfiguration);
-
+      LOGGER.debug("Merge default Dataproc conf: {}", DEFAULT_DATAPROC_ARGUMENT_FILE_NAME);
+      SpydraArgument dataprocDefaultConf = loadArguments(DEFAULT_DATAPROC_ARGUMENT_FILE_NAME);
+      // Merging default Dataproc configuration here before merging the given arguments below.
+      configuration = SpydraArgument.merge(configuration, dataprocDefaultConf);
       if (userId != null) {
+        LOGGER.debug("Set Dataproc service account user ID: {}", userId);
         configuration.getCluster().getOptions().put(OPTION_SERVICE_ACCOUNT, userId);
       }
     }

--- a/metrics/src/main/java/com/spotify/spydra/metrics/Metrics.java
+++ b/metrics/src/main/java/com/spotify/spydra/metrics/Metrics.java
@@ -30,7 +30,15 @@ public abstract class Metrics {
     return user;
   }
 
-  public abstract void clusterCreation(SpydraArgument arguments, boolean success);
+  /**
+   * Emit cluster creation metric.
+   *
+   * @param arguments The Spydra arguments.
+   * @param zoneUri   The zone URI where the cluster was created after successful cluster creation.
+   *                  This can be null, in case the cluster creation failed.
+   * @param success   Whether the cluster creation was successful.
+   */
+  public abstract void clusterCreation(SpydraArgument arguments, String zoneUri, boolean success);
 
   public abstract void clusterDeletion(SpydraArgument arguments, boolean success);
 

--- a/metrics/src/main/java/com/spotify/spydra/metrics/impl/LoggingMetrics.java
+++ b/metrics/src/main/java/com/spotify/spydra/metrics/impl/LoggingMetrics.java
@@ -31,8 +31,8 @@ public class LoggingMetrics extends Metrics {
   }
 
   @Override
-  public void clusterCreation(SpydraArgument arguments, boolean success) {
-    LOGGER.info("Cluster was created with success=" + success);
+  public void clusterCreation(SpydraArgument arguments, String zoneUri, boolean success) {
+    LOGGER.info("Cluster was created with success=" + success + " and zoneUri=" + zoneUri);
   }
 
   @Override


### PR DESCRIPTION
Using this new metric we can better follow where the Dataproc clusters get created in. I cleaned up also the configuration overwriting functionality, as I had hard time following it, causing me some extra wasted time effort.