### PR TITLE
Add support for graceful decommissioning

### DIFF
--- a/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
+++ b/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
@@ -124,7 +124,7 @@ public class SpydraArgument {
     public Optional<Integer> max = Optional.empty();
     public Optional<Double> factor = Optional.empty();
     public Optional<Boolean> downscale = Optional.empty();
-    public Optional<Integer> downscaleTimeout = Optional.of(10);
+    public Optional<Integer> downscaleTimeout = Optional.empty();
 
     public Integer getInterval() {
       return interval.get();

--- a/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
+++ b/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
@@ -124,6 +124,7 @@ public class SpydraArgument {
     public Optional<Integer> max = Optional.empty();
     public Optional<Double> factor = Optional.empty();
     public Optional<Boolean> downscale = Optional.empty();
+    public Optional<Integer> downscaleTimeout = Optional.of(10);
 
     public Integer getInterval() {
       return interval.get();
@@ -155,6 +156,14 @@ public class SpydraArgument {
 
     public void setDownscale(Boolean downscale) {
       this.downscale = Optional.of(downscale);
+    }
+
+    public Integer getDownscaleTimeout() {
+      return downscaleTimeout.get();
+    }
+
+    public void setDownscaleTimeout(Integer downscaleTimeout) {
+      this.downscaleTimeout = Optional.of(downscaleTimeout);
     }
   }
 

--- a/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
+++ b/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
@@ -41,6 +41,7 @@ public class SpydraArgumentUtil {
 
   public static SpydraArgument loadArguments(String fileName)
       throws IOException, URISyntaxException {
+    System.out.println("REMOVE ME " + fileName);
     ClassLoader classLoader = SpydraArgumentUtil.class.getClassLoader();
     try (InputStream is = classLoader.getResourceAsStream(fileName)) {
       if (is == null)
@@ -165,6 +166,8 @@ public class SpydraArgumentUtil {
       autoScaler.factor.orElseThrow(() ->
           new IllegalArgumentException("auto_scaler.factor needs to be set"));
       autoScaler.downscale.orElseThrow(()
+          -> new IllegalArgumentException("auto_scaler.downscale needs to be set"));
+      autoScaler.downscaleTimeout.orElseThrow(()
           -> new IllegalArgumentException("auto_scaler.downscale needs to be set"));
     });
     arguments.pooling.ifPresent(pooling -> {

--- a/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
+++ b/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
@@ -41,7 +41,6 @@ public class SpydraArgumentUtil {
 
   public static SpydraArgument loadArguments(String fileName)
       throws IOException, URISyntaxException {
-    System.out.println("REMOVE ME " + fileName);
     ClassLoader classLoader = SpydraArgumentUtil.class.getClassLoader();
     try (InputStream is = classLoader.getResourceAsStream(fileName)) {
       if (is == null)
@@ -168,7 +167,7 @@ public class SpydraArgumentUtil {
       autoScaler.downscale.orElseThrow(()
           -> new IllegalArgumentException("auto_scaler.downscale needs to be set"));
       autoScaler.downscaleTimeout.orElseThrow(()
-          -> new IllegalArgumentException("auto_scaler.downscale needs to be set"));
+          -> new IllegalArgumentException("auto_scaler.downscale_timeout needs to be set"));
     });
     arguments.pooling.ifPresent(pooling -> {
       pooling.limit.orElseThrow(() ->

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
@@ -185,6 +185,8 @@ public class DynamicSubmitter extends Submitter {
     list.add("autoscaler-factor=" + arguments.getAutoScaler().getFactor());
     list.add("autoscaler-mode="
         + (arguments.getAutoScaler().getDownscale() ? "downscale" : "upscale"));
+    list.add("autoscaler-downscale-timeout="
+        + arguments.getAutoScaler().getDownscaleTimeout());
     metadataArgument.cluster.getOptions()
         .put(SpydraArgument.OPTION_METADATA, StringUtils.join(list, ","));
     return SpydraArgument.merge(arguments, metadataArgument);

--- a/spydra/src/main/resources/spydra_config_schema.json
+++ b/spydra/src/main/resources/spydra_config_schema.json
@@ -103,6 +103,10 @@
         "downscale": {
           "description": "whether or not to enable downscaling",
           "type": "boolean"
+        },
+        "downscale_timeout": {
+          "description": "how long to wait in minutes for active jobs to finish before terminating nodes",
+          "type": "number"
         }
       }
     },


### PR DESCRIPTION
Hey I'm from the Google Dataproc team and I noticed that your autoscaler's downscaling is highly experimental. We recently launched graceful decommissioning to beta (https://cloud.google.com/dataproc/docs/concepts/scaling-clusters#using_graceful_decommissioning), and I think that will help.

Given that you think this PR is valuable, I'd appreciate any design feedback, particularly on how to specify the decommission timeout.