### PR TITLE
Remove PoolingSubmitter.Conditions.heartIsBeating

### DIFF
--- a/api/src/main/java/com/spotify/spydra/api/model/Cluster.java
+++ b/api/src/main/java/com/spotify/spydra/api/model/Cluster.java
@@ -45,6 +45,8 @@ public class Cluster {
       @JsonIgnoreProperties(ignoreUnknown = true)
       public static class Metadata {
 
+        // This is the initial heartbeat of the cluster. It is not updated.
+        // Look at the MasterConfig.instanceNames[0] for updated heartbeats
         public Optional<ZonedDateTime> heartbeat = Optional.empty();
       }
 

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
@@ -51,16 +51,6 @@ public class PoolingSubmitter extends DynamicSubmitter {
           .isAfter(ZonedDateTime.now(ZoneOffset.UTC));
     }
 
-    static boolean heartIsBeating(Cluster c, SpydraArgument arguments) {
-      Cluster.Config.GceClusterConfig.Metadata metadata = c.config.gceClusterConfig.metadata;
-      if (!metadata.heartbeat.isPresent()) {
-        return false;
-      }
-      ZonedDateTime heartbeat = metadata.heartbeat.get();
-      Integer collectorMinutes = arguments.getCollectorTimeoutMinutes();
-      return heartbeat.plusMinutes(collectorMinutes).isAfter(ZonedDateTime.now(ZoneOffset.UTC));
-    }
-
     public static boolean mayCreateMoreClusters(List<Cluster> filteredClusters,
         SpydraArgument arguments) {
       boolean may = filteredClusters.size() < arguments.getPooling().getLimit();
@@ -86,7 +76,6 @@ public class PoolingSubmitter extends DynamicSubmitter {
           .filter(Conditions::isSpydraCluster)
           .filter(Conditions::isRunning)
           .filter(c -> Conditions.isYoung(c, arguments))
-          .filter(c -> Conditions.heartIsBeating(c, arguments))
           .collect(Collectors.toList());
       if (Conditions.mayCreateMoreClusters(filteredClusters, arguments)) {
         return createNewCluster(arguments, dataprocAPI);

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
@@ -166,14 +166,6 @@ public class PoolingTest {
     }
 
     @Test
-    public void heartIsBeating() throws Exception {
-      SpydraArgument arguments = new SpydraArgument();
-      arguments.setCollectorTimeoutMinutes(30);
-      assertFalse(PoolingSubmitter.Conditions.heartIsBeating(ancientCluster(), arguments));
-      assertTrue(PoolingSubmitter.Conditions.heartIsBeating(perfectCluster(), arguments));
-    }
-
-    @Test
     public void mayCreateMoreClusters() throws Exception {
       ImmutableList<Cluster> clusters =
           ImmutableList.of(perfectCluster(), perfectCluster());


### PR DESCRIPTION
This implementation looks at the initial heartbeat set during cluster
creation. Hearbeat on the cluster is not updated and should not be used
for such a check. A proper check would look at the master node for each
cluster.

For now, we'll accept the small window where we could select a cluster
while it has already decided to self-destruct but it has not yet updated
it's state to `DELETING` yet. This transition usually is visible within
seconds from submitting a deletion.