### PR TITLE
Always require a userId

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To be able to use Dataproc and on-premise Hadoop, a few things need to be set up
 * [gcloud](https://cloud.google.com/sdk/gcloud/) needs to be installed
 * `gcloud` needs to be [authenticated using the service account](https://cloud.google.com/sdk/gcloud/reference/auth/)
 * The environment variable [GOOGLE_APPLICATION_CREDENTIALS](https://developers.google.com/identity/protocols/application-default-credentials)
-  needs to point to the location of the service account JSON key
+  needs to point to the location of the service account JSON key. This cannot be a user credential.
 * [hadoop jar](https://hadoop.apache.org/docs/r2.6.0/hadoop-project-dist/hadoop-common/CommandsManual.html#jar)
   needs to be installed and configured to submit to your cluster
 

--- a/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
+++ b/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
@@ -89,10 +89,8 @@ public class SpydraArgumentUtil {
           new String[]{BASE_CONFIGURATION_FILE_NAME, DEFAULT_DATAPROC_ARGUMENT_FILE_NAME,
                        SPYDRA_CONFIGURATION_FILE_NAME},
           arguments);
-      if (userId != null) {
-        LOGGER.debug("Set Dataproc service account user ID: {}", userId);
-        outputConfig.getCluster().getOptions().put(OPTION_SERVICE_ACCOUNT, userId);
-      }
+      LOGGER.debug("Set Dataproc service account user ID: {}", userId);
+      outputConfig.getCluster().getOptions().put(OPTION_SERVICE_ACCOUNT, userId);
     } else {
       outputConfig = baseArgsWithGivenArgs;
     }

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/Runner.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/Runner.java
@@ -95,8 +95,10 @@ public class Runner {
 
     SpydraArgument userArguments = parser.parse(args);
     Optional<String> userId = userId(SpydraArgumentUtil.isOnPremiseInvocation(userArguments));
+    userId.orElseThrow(() -> new IllegalArgumentException(
+        "No valid credentials (service account) were available to forward to the cluster."));
     SpydraArgument finalArguments =
-        SpydraArgumentUtil.mergeConfigurations(userArguments, userId.orElse(null));
+        SpydraArgumentUtil.mergeConfigurations(userArguments, userId.get());
     SpydraArgumentUtil.setDefaultClientIdIfRequired(finalArguments);
     finalArguments.replacePlaceholders();
 


### PR DESCRIPTION
Not using a service account credential (silently) breaks all
the rest of Spydra.