### PR TITLE
Add account gcloud parameter

### DIFF
--- a/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
+++ b/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
@@ -39,6 +39,11 @@ public class DataprocAPI {
     metrics = MetricsFactory.getInstance();
   }
 
+  public DataprocAPI(String account) {
+    gcloud = new GcloudExecutor(account);
+    metrics = MetricsFactory.getInstance();
+  }
+
   @VisibleForTesting
   DataprocAPI(GcloudExecutor gcloud, Metrics metrics) {
     this.gcloud = gcloud;

--- a/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudExecutor.java
+++ b/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudExecutor.java
@@ -46,15 +46,18 @@ public class GcloudExecutor {
   private static final String DEFAULT_GCLOUD_COMMAND = "gcloud";
 
   private final String baseCommand;
+  private final String account;
 
   private boolean dryRun = false;
 
   public GcloudExecutor() {
-    this(DEFAULT_GCLOUD_COMMAND);
+    this.baseCommand = DEFAULT_GCLOUD_COMMAND;
+    this.account = null;
   }
 
-  public GcloudExecutor(String gcloudCommand) {
-    baseCommand = gcloudCommand;
+  public GcloudExecutor(String account) {
+    this.baseCommand = DEFAULT_GCLOUD_COMMAND;
+    this.account = account;
   }
 
   public Optional<Cluster> createCluster(String name, String region, Map<String, String> args) throws IOException {
@@ -87,7 +90,10 @@ public class GcloudExecutor {
   private ArrayList<String> buildCommand(List<String> commands, Map<String, String> options, List<String> jobArgs) {
 
     ArrayList<String> command = Lists.newArrayList(this.baseCommand);
-
+    if (account != null && !account.isEmpty()) {
+      command.add("--account");
+      command.add(account);
+    }
     command.addAll(commands);
     command.add(createOption("quiet", ""));
     options.entrySet().forEach(entry -> command.add(createOption(entry.getKey(), entry.getValue())));

--- a/common/src/main/java/com/spotify/spydra/util/GcpUtils.java
+++ b/common/src/main/java/com/spotify/spydra/util/GcpUtils.java
@@ -75,13 +75,19 @@ public class GcpUtils {
     }
   }
 
-  public Optional<String> userIdFromJsonCredential(String json) {
+  private Optional<String> userIdFromJsonCredential(String json) {
     try {
       return Optional.of(JsonPath.read(json, "$.client_email"));
     } catch (PathNotFoundException ex) {
       LOGGER.info("Could not parse client_email from credentials.");
       return Optional.empty();
     }
+  }
+
+  public String userIdFromJsonCredentialInEnv() throws IOException {
+    return userIdFromJsonCredential(credentialJsonFromEnv()).orElseThrow(
+        () -> new IllegalArgumentException(
+          "No valid credentials (service account) were available to forward to the cluster."));
   }
 
   public void configureClusterProjectFromCredential(SpydraArgument arguments)

--- a/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
+++ b/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
@@ -111,10 +111,8 @@ public class SpydraArgumentUtil {
                      SPYDRA_CONFIGURATION_FILE_NAME},
         base);
     GcpUtils gcpUtils = new GcpUtils();
-    String credential = gcpUtils.credentialJsonFromEnv();
-    gcpUtils.userIdFromJsonCredential(credential)
-        .orElseThrow(() -> new IllegalArgumentException(
-            "No valid credentials (service account) were available to forward to the cluster."));
+    defaults.getCluster().getOptions().put(
+        SpydraArgument.OPTION_SERVICE_ACCOUNT, gcpUtils.userIdFromJsonCredentialInEnv());
     gcpUtils.configureClusterProjectFromCredential(defaults);
     defaults.replacePlaceholders();
     return defaults;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
@@ -64,6 +64,10 @@ public class DynamicSubmitter extends Submitter {
     this(new DataprocAPI(), new GcpUtils());
   }
 
+  public DynamicSubmitter(String account) {
+    this(new DataprocAPI(account), new GcpUtils());
+  }
+
   public DynamicSubmitter(DataprocAPI dataprocAPI, GcpUtils gcpUtils) {
     this.dataprocAPI = dataprocAPI;
     this.gcpUtils = gcpUtils;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
@@ -36,6 +36,14 @@ public class PoolingSubmitter extends DynamicSubmitter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicSubmitter.class);
 
+  public PoolingSubmitter() {
+    super();
+  }
+
+  public PoolingSubmitter(String account) {
+    super(account);
+  }
+
   static final class Conditions {
 
     static boolean isSpydraCluster(Cluster c) {

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
@@ -44,10 +44,12 @@ public class Submitter {
         .isOnPremiseInvocation(arguments)) {
       submitter = new Submitter();
     } else {
+      String account =
+          arguments.getCluster().getOptions().get(SpydraArgument.OPTION_SERVICE_ACCOUNT);
       if (arguments.isPoolingEnabled()) {
-        submitter = new PoolingSubmitter();
+        submitter = new PoolingSubmitter(account);
       } else {
-        submitter = new DynamicSubmitter();
+        submitter = new DynamicSubmitter(account);
       }
     }
     return submitter;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/executor/DataprocExecutor.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/executor/DataprocExecutor.java
@@ -17,6 +17,8 @@
 
 package com.spotify.spydra.submitter.executor;
 
+import static com.spotify.spydra.model.SpydraArgument.OPTION_SERVICE_ACCOUNT;
+
 import com.spotify.spydra.api.DataprocAPI;
 import com.spotify.spydra.model.SpydraArgument;
 
@@ -26,7 +28,8 @@ public class DataprocExecutor implements Executor {
 
   @Override
   public boolean submit(SpydraArgument arguments) throws IOException {
-    DataprocAPI dataprocAPI = new DataprocAPI();
+    DataprocAPI dataprocAPI =
+        new DataprocAPI(arguments.getCluster().getOptions().get(OPTION_SERVICE_ACCOUNT));
     dataprocAPI.dryRun(arguments.isDryRun());
     return dataprocAPI.submit(arguments);
   }

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/Runner.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/Runner.java
@@ -118,9 +118,7 @@ public class Runner {
     if (onPremiseInvocation) {
       return Optional.ofNullable(System.getenv("HADOOP_USER_NAME")).orElse("onpremise");
     } else {
-      return gcpUtils.userIdFromJsonCredential(gcpUtils.credentialJsonFromEnv()).orElseThrow(
-          () -> new IllegalArgumentException(
-              "No valid credentials (service account) were available to forward to the cluster."));
+      return gcpUtils.userIdFromJsonCredentialInEnv();
     }
   }
 

--- a/spydra/src/test/java/com/spotify/spydra/LifecycleIT.java
+++ b/spydra/src/test/java/com/spotify/spydra/LifecycleIT.java
@@ -79,6 +79,8 @@ public class LifecycleIT {
     // Merge to get all other custom test arguments
     arguments = SpydraArgument.merge(arguments, testArgs);
 
+    LOGGER.debug("Using following service account to run gcloud commands locally: " +
+        arguments.getCluster().getOptions().get(SpydraArgument.OPTION_SERVICE_ACCOUNT));
     Submitter submitter = Submitter.getSubmitter(arguments);
     assertTrue("job wasn't successful", submitter.executeJob(arguments));
 


### PR DESCRIPTION
Using account parameter with gcloud command locally makes spydra use the provided credential for the spydra command, and not the default from gcloud session outside spydra.