### PR TITLE
Enable MR intermediate and fileoutput compression by default

### DIFF
--- a/spydra/src/main/resources/dataproc_defaults.json
+++ b/spydra/src/main/resources/dataproc_defaults.json
@@ -8,7 +8,7 @@
     "options": {
       "scopes": "cloud-platform",
       "initialization-actions": "${versioned-init-action-uri}/self-destruct.sh,${versioned-init-action-uri}/autoscaler.sh",
-      "properties": "mapred:mapreduce.jobhistory.done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/done,mapred:mapreduce.jobhistory.intermediate-done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/${UUID}/done_intermediate,mapred:mapreduce.jobhistory.move.interval-ms=1000,core:fs.gs.parent.timestamp.update.substrings.includes=gs://${LOG_BUCKET}/history,yarn:yarn.log-aggregation-enable=true,yarn:yarn.nodemanager.remote-app-log-dir=gs://${LOG_BUCKET}/logs/${CLIENT_ID},yarn:yarn.log-aggregation.retain-seconds=-1,core:fs.gs.implicit.directory.repair=false"
+      "properties": "mapred:mapreduce.jobhistory.done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/done,mapred:mapreduce.jobhistory.intermediate-done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/${UUID}/done_intermediate,mapred:mapreduce.jobhistory.move.interval-ms=1000,mapred:mapreduce.output.fileoutputformat.compress=true,mapred:mapreduce.map.output.compress=true,mapred:mapreduce.output.fileoutputformat.compress.type=BLOCK,core:fs.gs.parent.timestamp.update.substrings.includes=gs://${LOG_BUCKET}/history,yarn:yarn.log-aggregation-enable=true,yarn:yarn.nodemanager.remote-app-log-dir=gs://${LOG_BUCKET}/logs/${CLIENT_ID},yarn:yarn.log-aggregation.retain-seconds=-1,core:fs.gs.implicit.directory.repair=false"
     }
   },
   "submit": {


### PR DESCRIPTION
As a good practice to optimize network and storage usage I propose to enable compression by default in map-reduce applications.