### PR TITLE
Fix undefined name in releaseCluster

### DIFF
--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
@@ -173,6 +173,7 @@ public class DynamicSubmitter extends Submitter {
   }
 
   protected void mutateForCluster(SpydraArgument arguments, String name, String zone) {
+    arguments.getCluster().setName(name);
     arguments.getCluster().getOptions().put(OPTION_ZONE, zone);
     arguments.getSubmit().getOptions().put(OPTION_CLUSTER, name);
     arguments.getSubmit().getOptions().put(OPTION_PROJECT,

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
@@ -115,7 +115,7 @@ public class PoolingTest {
       assertTrue("Failed to acquire a cluster", result);
       verify(dataprocAPI, never()).createCluster(arguments);
 
-      poolingSubmitter.releaseCluster(arguments, dataprocAPI);
+      assertTrue("A healthy cluster should be kept without problems.", poolingSubmitter.releaseCluster(arguments, dataprocAPI));
       verify(dataprocAPI, never()).deleteCluster(arguments);
 
     }

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
@@ -97,7 +97,7 @@ public class PoolingTest {
     }
 
     @Test
-    public void acquirePooledCluster() throws Exception {
+    public void acquireAndReleasePooledCluster() throws Exception {
       ImmutableList<Cluster> clusters =
           ImmutableList.of(perfectCluster(), perfectCluster(), nonSpydraCluster());
 
@@ -114,6 +114,10 @@ public class PoolingTest {
       boolean result = poolingSubmitter.acquireCluster(arguments, dataprocAPI);
       assertTrue("Failed to acquire a cluster", result);
       verify(dataprocAPI, never()).createCluster(arguments);
+
+      poolingSubmitter.releaseCluster(arguments, dataprocAPI);
+      verify(dataprocAPI, never()).deleteCluster(arguments);
+
     }
 
     @Test


### PR DESCRIPTION
The aim of this PR is to solve the exception `java.util.NoSuchElementException: No value present` thrown when a new job is submitted to a cluster that has been previously created (using pooling). In that case, the cluster name has not been set and consequently the check of the cluster name in `releaseCluster` fails.

See trace below:
```
Exception in thread "main" java.util.NoSuchElementException: No value present
    at java.util.Optional.get(Optional.java:135)
    at com.spotify.spydra.model.SpydraArgument$Cluster.getName(SpydraArgument.java:90)
    at com.spotify.spydra.submitter.api.PoolingSubmitter.lambda$releaseCluster$1(PoolingSubmitter.java:112)
    at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174)
    at java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:958)
    at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
    at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:498)
    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
    at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.findAny(ReferencePipeline.java:469)
    at com.spotify.spydra.submitter.api.PoolingSubmitter.releaseCluster(PoolingSubmitter.java:113)
    at com.spotify.spydra.submitter.api.DynamicSubmitter.executeJob(DynamicSubmitter.java:136)
    at com.spotify.spydra.submitter.runner.Runner.runSubmit(Runner.java:107)
    at com.spotify.spydra.submitter.runner.Runner.main(Runner.java:60)
```