### PR TITLE
Sort and limit poolable clusters

### DIFF
--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
@@ -25,6 +25,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -82,6 +83,9 @@ public class PoolingSubmitter extends DynamicSubmitter {
           .filter(Conditions::isSpydraCluster)
           .filter(Conditions::isRunning)
           .filter(c -> Conditions.isYoung(c, arguments))
+          // Sort and limit to eventually over time arrive at the limit
+          .sorted(Comparator.comparing(c -> c.clusterName))
+          .limit(arguments.getPooling().getLimit())
           .collect(Collectors.toList());
       if (Conditions.mayCreateMoreClusters(filteredClusters, arguments)) {
         return createNewCluster(arguments, dataprocAPI);


### PR DESCRIPTION
This significantly reduces the time for the limit to stabilize after
fluctuations due to multiple actors racing to create clusters