### PR TITLE
Fix pooling #48

### DIFF
--- a/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
+++ b/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
@@ -26,6 +26,7 @@ import com.spotify.spydra.metrics.MetricsFactory;
 import com.spotify.spydra.model.SpydraArgument;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 public class DataprocAPI {
@@ -113,7 +114,7 @@ public class DataprocAPI {
     return success;
   }
 
-  public Collection<Cluster> listClusters(SpydraArgument arguments) throws IOException {
-    return gcloud.listClusters(arguments.cluster.getOptions().get("project"), arguments.getRegion());
+  public Collection<Cluster> listClusters(SpydraArgument arguments, Map<String, String> filters) throws IOException {
+    return gcloud.listClusters(arguments.cluster.getOptions().get("project"), arguments.getRegion(), filters);
   }
 }

--- a/api/src/main/java/com/spotify/spydra/api/model/Cluster.java
+++ b/api/src/main/java/com/spotify/spydra/api/model/Cluster.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -68,6 +69,9 @@ public class Cluster {
   public Config config = new Config();
 
   public String clusterName;
+
+  public Map<String, String> labels;
+
   //TODO: TW Look at the `metrics` for the cluster
   //TODO: TW look at labels to see if it is a spydra created cluster?
 }

--- a/api/src/main/java/com/spotify/spydra/api/model/Cluster.java
+++ b/api/src/main/java/com/spotify/spydra/api/model/Cluster.java
@@ -20,6 +20,7 @@ package com.spotify.spydra.api.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
+++ b/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
@@ -49,6 +49,9 @@ public class SpydraArgument {
   public static final String OPTION_TAGS = "tags";
   public static final String OPTION_SERVICE_ACCOUNT = "service-account";
   public static final String OPTION_JOB_ID = "id";
+  public static final String OPTIONS_FILTER = "filter";
+  public static final String OPTIONS_FILTER_LABEL_PREFIX = "labels.";
+
 
   public static final String JOB_TYPE_HADOOP = "hadoop";
   public static final String JOB_TYPE_PYSPARK = "pyspark";

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
@@ -55,7 +55,7 @@ public class DynamicSubmitter extends Submitter {
   private final static String METADATA_KEY = "heartbeat";
   private final static String COLLECTOR_INTERVAL_KEY = "collector-timeout";
 
-  private final static String SPYDRA_CLUSTER_LABEL = "spydra-cluster";
+  public final static String SPYDRA_CLUSTER_LABEL = "spydra-cluster";
 
   private final DataprocAPI dataprocAPI;
   private final GcpUtils gcpUtils;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
@@ -55,6 +55,8 @@ public class DynamicSubmitter extends Submitter {
   private final static String METADATA_KEY = "heartbeat";
   private final static String COLLECTOR_INTERVAL_KEY = "collector-timeout";
 
+  private final static String SPYDRA_CLUSTER_LABEL = "spydra-cluster";
+
   private final DataprocAPI dataprocAPI;
   private final GcpUtils gcpUtils;
 
@@ -155,6 +157,9 @@ public class DynamicSubmitter extends Submitter {
     } else {
       createArguments = arguments;
     }
+
+    arguments.addOption(createArguments.cluster.options, SpydraArgument.OPTION_LABELS, SPYDRA_CLUSTER_LABEL + "=1");
+
     randomizeZoneIfAbsent(createArguments);
 
     Optional<Cluster> cluster = dataprocAPI.createCluster(createArguments);

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
@@ -17,15 +17,8 @@
 
 package com.spotify.spydra.submitter.api;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.spotify.spydra.api.DataprocAPI;
 import com.spotify.spydra.api.model.Cluster;
 import com.spotify.spydra.model.SpydraArgument;
@@ -38,47 +31,65 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 @RunWith(Enclosed.class)
 public class PoolingTest {
   private static final String spydraClusterName = "spydra-uuid";
   private static final String nonSpydraClusterName = "not-a-spydra-cluster";
 
-  static Cluster perfectCluster() {
+  static Cluster perfectCluster(String clientid) {
     Cluster cluster = new Cluster();
     cluster.clusterName = spydraClusterName;
     Cluster.Status status = new Cluster.Status();
     status.state = Cluster.Status.RUNNING;
     status.stateStartTime = ZonedDateTime.now(ZoneOffset.UTC);
     cluster.status = status;
+    cluster.labels = ImmutableMap.of(DynamicSubmitter.SPYDRA_CLUSTER_LABEL, "1",
+                                     PoolingSubmitter.POOLED_CLUSTER_CLIENTID_LABEL, clientid);
     cluster.config.gceClusterConfig.metadata.heartbeat =
         Optional.of(cluster.status.stateStartTime.plusMinutes(60));
     return cluster;
   }
 
-  static Cluster nonSpydraCluster() {
+  static Cluster nonSpydraCluster(String clientid) {
     Cluster cluster = new Cluster();
-    cluster.clusterName = nonSpydraClusterName;
+    cluster.labels = ImmutableMap.of();
+    cluster.clusterName = "not-a-spydra-cluster";
     Cluster.Status status = new Cluster.Status();
+    cluster.labels = ImmutableMap.of(DynamicSubmitter.SPYDRA_CLUSTER_LABEL, "1",
+                                     PoolingSubmitter.POOLED_CLUSTER_CLIENTID_LABEL, clientid);
     status.state = Cluster.Status.RUNNING;
     status.stateStartTime = ZonedDateTime.now(ZoneOffset.UTC);
     return cluster;
   }
 
-  static Cluster creatingCluster() {
-    Cluster cluster = perfectCluster();
-    cluster.status.state = Cluster.Status.CREATING;
+  static Cluster creatingCluster(String clientid) {
+    Cluster cluster = perfectCluster(clientid);
+    cluster.status.state = "CREATING";
     return cluster;
   }
 
-  static Cluster ancientCluster() {
-    Cluster cluster = perfectCluster();
+  static Cluster ancientCluster(String clientid) {
+    Cluster cluster = perfectCluster(clientid);
+
+    //Make cluster an hour older, and last heartbeat 30 minutes ago
+    cluster.status.stateStartTime = cluster.status.stateStartTime.minusMinutes(60);
     cluster.config.gceClusterConfig.metadata.heartbeat =
         Optional.of(cluster.status.stateStartTime.minusMinutes(30));
     return cluster;
   }
 
-  static Cluster errorCluster() {
-    Cluster cluster = perfectCluster();
+  static Cluster errorCluster(String clientid) {
+    Cluster cluster = perfectCluster(clientid);
     cluster.status.state = Cluster.Status.ERROR;
     return cluster;
   }
@@ -88,29 +99,34 @@ public class PoolingTest {
     PoolingSubmitter poolingSubmitter;
     DataprocAPI dataprocAPI;
     SpydraArgument arguments;
+    String clientId;
 
     @Before
     public void before() {
       poolingSubmitter = new PoolingSubmitter();
       dataprocAPI = mock(DataprocAPI.class);
       arguments = new SpydraArgument();
+      clientId = "my-client-id";
     }
 
     @Test
-    public void acquireAndReleasePooledCluster() throws Exception {
+    public void acquirePooledCluster() throws Exception {
+
       ImmutableList<Cluster> clusters =
-          ImmutableList.of(perfectCluster(), perfectCluster(), nonSpydraCluster());
+          ImmutableList.of(perfectCluster(clientId), perfectCluster(clientId));
 
       SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
       pooling.setLimit(2); // 2 perfectly suited clusters above!
       pooling.setMaxAge(Duration.ofMinutes(30));
+      arguments.setClientId(clientId);
       arguments.setPooling(pooling);
       arguments.setCollectorTimeoutMinutes(10);
 
-      when(dataprocAPI.listClusters(arguments))
+      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
           .thenReturn(clusters);
       when(dataprocAPI.createCluster(arguments))
-          .thenReturn(Optional.of(perfectCluster()));
+          .thenReturn(Optional.of(new Cluster()));
+
       boolean result = poolingSubmitter.acquireCluster(arguments, dataprocAPI);
       assertTrue("Failed to acquire a cluster", result);
       verify(dataprocAPI, never()).createCluster(arguments);
@@ -121,20 +137,43 @@ public class PoolingTest {
     }
 
     @Test
+    public void avoidAncientCluster() throws Exception {
+      ImmutableList<Cluster> clusters =
+          ImmutableList.of(ancientCluster(clientId), ancientCluster(clientId));
+
+      SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
+      pooling.setLimit(2); // 2 reasonable but old clusters above. Pool is "full", but none usable.
+      pooling.setMaxAge(Duration.ofMinutes(30));
+      arguments.setClientId(clientId);
+      arguments.setPooling(pooling);
+      arguments.setCollectorTimeoutMinutes(10);
+
+      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
+          .thenReturn(clusters);
+      when(dataprocAPI.createCluster(arguments))
+          .thenReturn(Optional.of(new Cluster()));
+
+      boolean result = poolingSubmitter.acquireCluster(arguments, dataprocAPI);
+      assertTrue("Failed to acquire a cluster", result);
+      verify(dataprocAPI, times(1)).createCluster(arguments);
+    }
+
+    @Test
     public void acquireNewCluster() throws Exception {
       ImmutableList<Cluster> clusters =
-          ImmutableList.of(perfectCluster(), perfectCluster(), nonSpydraCluster());
+          ImmutableList.of(perfectCluster(clientId), perfectCluster(clientId));
 
       SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
       pooling.setLimit(3); // 2 perfectly suited clusters above, so room for 1 more!
       pooling.setMaxAge(Duration.ofMinutes(30));
       arguments.setPooling(pooling);
       arguments.setCollectorTimeoutMinutes(10);
+      arguments.setClientId(clientId);
 
-      when(dataprocAPI.listClusters(arguments))
+      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
           .thenReturn(clusters);
       when(dataprocAPI.createCluster(arguments))
-          .thenReturn(Optional.of(perfectCluster()));
+          .thenReturn(Optional.of(new Cluster()));
       boolean result = poolingSubmitter.acquireCluster(arguments, dataprocAPI);
       assertTrue("Failed to acquire a cluster", result);
       verify(dataprocAPI, times(1)).createCluster(arguments);
@@ -142,24 +181,36 @@ public class PoolingTest {
 
     @Test
     public void releaseCluster() throws Exception {
-      arguments.setPooling(new SpydraArgument.Pooling());
+      ImmutableList<Cluster> clusters =
+          ImmutableList.of(perfectCluster(clientId), perfectCluster(clientId));
+
+      SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
+      arguments.setPooling(pooling);
+      arguments.setClientId(clientId);
       arguments.cluster.setName(spydraClusterName);
 
-      when(dataprocAPI.listClusters(arguments)).thenReturn(ImmutableList.of(perfectCluster()));
+      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
+           .thenReturn(clusters);
       assertTrue("A healthy cluster should be kept without problems.", poolingSubmitter.releaseCluster(arguments, dataprocAPI));
-      verify(dataprocAPI).listClusters(arguments);
+      verify(dataprocAPI).listClusters(eq(arguments), anyMap());
       verify(dataprocAPI, never()).deleteCluster(arguments);
     }
 
     @Test
     public void releaseErrorCluster() throws Exception {
-      arguments.setPooling(new SpydraArgument.Pooling());
+      ImmutableList<Cluster> clusters =
+              ImmutableList.of(errorCluster(clientId), errorCluster(clientId));
+
+      SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
+      arguments.setPooling(pooling);
+      arguments.setClientId(clientId);
       arguments.cluster.setName(spydraClusterName);
 
-      when(dataprocAPI.listClusters(arguments)).thenReturn(ImmutableList.of(errorCluster()));
+      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
+           .thenReturn(clusters);
       when(dataprocAPI.deleteCluster(arguments)).thenReturn(true);
       assertTrue("A broken cluster should be collected without problems.", poolingSubmitter.releaseCluster(arguments, dataprocAPI));
-      verify(dataprocAPI).listClusters(arguments);
+      verify(dataprocAPI).listClusters(eq(arguments), anyMap());
       verify(dataprocAPI).deleteCluster(arguments);
     }
   }
@@ -167,35 +218,27 @@ public class PoolingTest {
   public static class PoolingConditionsTest {
 
     @Test
-    public void isSpydraCluster() throws Exception {
-      assertTrue(PoolingSubmitter.Conditions.isSpydraCluster(perfectCluster()));
-      assertFalse(PoolingSubmitter.Conditions.isSpydraCluster(nonSpydraCluster()));
-    }
-
-    @Test
-    public void isRunning() throws Exception {
-      assertTrue(PoolingSubmitter.Conditions.isRunning(perfectCluster()));
-      assertFalse(PoolingSubmitter.Conditions.isRunning(creatingCluster()));
-    }
-
-    @Test
     public void isYoung() throws Exception {
+      String clientId = "some-client-id";
       SpydraArgument arguments = new SpydraArgument();
       SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
       pooling.setMaxAge(Duration.ofMinutes(30));
       arguments.setPooling(pooling);
-      assertTrue(PoolingSubmitter.Conditions.isYoung(perfectCluster(), arguments));
+      arguments.setClientId(clientId);
+      assertTrue(PoolingSubmitter.Conditions.isYoung(perfectCluster(clientId), arguments));
     }
 
     @Test
     public void mayCreateMoreClusters() throws Exception {
+      String myClientId="some-client-id";
       ImmutableList<Cluster> clusters =
-          ImmutableList.of(perfectCluster(), perfectCluster());
+          ImmutableList.of(perfectCluster(myClientId), perfectCluster(myClientId));
       SpydraArgument arguments = new SpydraArgument();
       SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
       pooling.setLimit(2);
       pooling.setMaxAge(Duration.ofMinutes(30));
       arguments.setPooling(pooling);
+      arguments.setClientId(myClientId);
 
       assertFalse(PoolingSubmitter.Conditions.mayCreateMoreClusters(clusters, arguments));
 


### PR DESCRIPTION
This PR is to fix #48 
PoolingSubmitter looks at all clusters in a project, this should be segmented on a user provided value allowing multiple pools to coexist in a single project.

