### PR TITLE
Mapreduce default parameter tuning - sort & copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ To enable cluster pooling add a pooling section similar to the one below to your
      instead of getting the correct filesystem for a given URI. It can also lead to the Crunch
      output committer working very slowly while copying all files from HDFS to GCS in a
      last non-distributed step.
+   * As we overwrite some default mapreduce memory parameters to optimize for typical workload
+     avoid using the smallest instances like n1-standard-1 (4GB RAM) or otherwise adjust accordingly.
 
 #### Running an Embedded JobHistoryServer
 The *run-jhs* is designed for an interactive exploration of the job execution. This command spawns an embedded 

--- a/spydra/src/main/resources/dataproc_defaults.json
+++ b/spydra/src/main/resources/dataproc_defaults.json
@@ -8,7 +8,7 @@
     "options": {
       "scopes": "cloud-platform",
       "initialization-actions": "${versioned-init-action-uri}/self-destruct.sh,${versioned-init-action-uri}/autoscaler.sh",
-      "properties": "mapred:mapreduce.jobhistory.done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/done,mapred:mapreduce.jobhistory.intermediate-done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/${UUID}/done_intermediate,mapred:mapreduce.jobhistory.move.interval-ms=1000,mapred:mapreduce.output.fileoutputformat.compress=true,mapred:mapreduce.map.output.compress=true,mapred:mapreduce.output.fileoutputformat.compress.type=BLOCK,core:fs.gs.parent.timestamp.update.substrings.includes=gs://${LOG_BUCKET}/history,yarn:yarn.log-aggregation-enable=true,yarn:yarn.nodemanager.remote-app-log-dir=gs://${LOG_BUCKET}/logs/${CLIENT_ID},yarn:yarn.log-aggregation.retain-seconds=-1,core:fs.gs.implicit.directory.repair=false"
+      "properties": "mapred:mapreduce.jobhistory.done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/done,mapred:mapreduce.jobhistory.intermediate-done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/${UUID}/done_intermediate,mapred:mapreduce.task.io.sort.mb=600,mapred:mapreduce.reduce.shuffle.parallelcopies=20,mapred:mapreduce.jobhistory.move.interval-ms=1000,mapred:mapreduce.output.fileoutputformat.compress=true,mapred:mapreduce.map.output.compress=true,mapred:mapreduce.output.fileoutputformat.compress.type=BLOCK,core:fs.gs.parent.timestamp.update.substrings.includes=gs://${LOG_BUCKET}/history,yarn:yarn.log-aggregation-enable=true,yarn:yarn.nodemanager.remote-app-log-dir=gs://${LOG_BUCKET}/logs/${CLIENT_ID},yarn:yarn.log-aggregation.retain-seconds=-1,core:fs.gs.implicit.directory.repair=false"
     }
   },
   "submit": {


### PR DESCRIPTION
This is the proposal to increase mapreduce sort buffer to reduce number of spills and improve performance. Furthermore increase number of parallel copies cut time required to copy the data from mappers to reducers by allocating more threads for this operation.