### PR TITLE
Make gcloud errors non-fatal

### DIFF
--- a/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudExecutor.java
+++ b/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudExecutor.java
@@ -92,9 +92,9 @@ public class GcloudExecutor {
     return execute(submitCommand, submitOptions, jobArgs);
   }
 
-  private ArrayList<String> buildCommand(List<String> commands, Map<String, String> options, List<String> jobArgs) {
+  private List<String> buildCommand(List<String> commands, Map<String, String> options, List<String> jobArgs) {
 
-    ArrayList<String> command = Lists.newArrayList(this.baseCommand);
+    List<String> command = Lists.newArrayList(this.baseCommand);
     if (account != null && !account.isEmpty()) {
       command.add("--account");
       command.add(account);
@@ -112,8 +112,7 @@ public class GcloudExecutor {
 
   private boolean execute(List<String> commands, Map<String, String> options, List<String> jobArgs)
       throws IOException {
-    ArrayList<String> command = buildCommand(commands, options, jobArgs);
-
+    List<String> command = buildCommand(commands, options, jobArgs);
     if (this.dryRun) {
       System.out.println(StringUtils.join(command, StringUtils.SPACE));
       return true;
@@ -124,7 +123,7 @@ public class GcloudExecutor {
 
   public String getMasterNode(String project, String region, String clusterName)
       throws IOException {
-    ArrayList<String> command = Lists.newArrayList(
+    List<String> command = Lists.newArrayList(
         "--format=json", "dataproc", "clusters", "describe", clusterName);
 
     Map<String, String> options = ImmutableMap.of(

--- a/api/src/main/java/com/spotify/spydra/api/process/ProcessHelper.java
+++ b/api/src/main/java/com/spotify/spydra/api/process/ProcessHelper.java
@@ -21,6 +21,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
+import jdk.nashorn.tools.Shell;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,10 +58,11 @@ public class ProcessHelper {
       BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
       String line;
       while ((line = in.readLine()) != null) {
-        outputBuilder.append(line + System.getProperty("line.separator"));
+        String lineWithSep = line + System.getProperty("line.separator");
+        outputBuilder.append(lineWithSep);
       }
       int exitCode = p.waitFor();
-      return exitCode == 0;
+      return exitCode == Shell.SUCCESS;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       p.destroy();

--- a/api/src/main/java/com/spotify/spydra/api/process/ProcessHelper.java
+++ b/api/src/main/java/com/spotify/spydra/api/process/ProcessHelper.java
@@ -45,7 +45,8 @@ public class ProcessHelper {
     return p.exitValue();
   }
 
-  public static String executeForOutput(List<String> command) throws IOException {
+  public static boolean executeForOutput(List<String> command, StringBuilder outputBuilder)
+      throws IOException {
     LOGGER.debug("Executing command: " + StringUtils.join(command, " "));
     ProcessBuilder pb = new ProcessBuilder(command)
         .redirectError(ProcessBuilder.Redirect.INHERIT)
@@ -54,13 +55,12 @@ public class ProcessHelper {
     Process p = pb.start();
     try {
       BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
-      StringBuilder builder = new StringBuilder();
       String line;
       while ((line = in.readLine()) != null) {
-        builder.append(line + System.getProperty("line.separator"));
+        outputBuilder.append(line + System.getProperty("line.separator"));
       }
-      p.waitFor();
-      return builder.toString();
+      int exitCode = p.waitFor();
+      return exitCode == 0;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       p.destroy();

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
@@ -28,12 +28,14 @@ import com.spotify.spydra.metrics.Metrics;
 import com.spotify.spydra.metrics.MetricsFactory;
 import com.spotify.spydra.model.SpydraArgument;
 import com.spotify.spydra.util.GcpUtils;
+
 import java.io.IOException;
 import java.net.URI;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -185,7 +187,7 @@ public class DynamicSubmitter extends Submitter {
 
   private SpydraArgument configureAutoScaler(SpydraArgument arguments) {
     SpydraArgument metadataArgument = new SpydraArgument();
-    ArrayList<String> list = new ArrayList<>();
+    List<String> list = new ArrayList<>();
     list.add("autoscaler-interval=" + arguments.getAutoScaler().getInterval());
     list.add("autoscaler-max=" + arguments.getAutoScaler().getMax());
     list.add("autoscaler-factor=" + arguments.getAutoScaler().getFactor());

--- a/spydra/src/main/java/com/spotify/spydra/submitter/executor/OnPremiseExecutor.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/executor/OnPremiseExecutor.java
@@ -44,7 +44,7 @@ public class OnPremiseExecutor implements Executor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OnPremiseExecutor.class);
 
-  private ArrayList<String> command = new ArrayList<>();
+  private List<String> command = new ArrayList<>();
 
   public OnPremiseExecutor() {
     metrics = MetricsFactory.getInstance();
@@ -56,7 +56,7 @@ public class OnPremiseExecutor implements Executor {
   }
 
   @VisibleForTesting
-  ArrayList<String> getCommand(SpydraArgument arguments) {
+  List<String> getCommand(SpydraArgument arguments) {
     addBaseCommand();
 
     if (arguments.getSubmit().getOptions().containsKey(OPTION_JAR)) {
@@ -101,7 +101,7 @@ public class OnPremiseExecutor implements Executor {
       throw new IllegalArgumentException("Default executor does only supports Hadoop jobs");
     }
 
-    ArrayList<String> command = getCommand(arguments);
+    List<String> command = getCommand(arguments);
     String fullCommand = StringUtils.join(command, StringUtils.SPACE);
     LOGGER.info("Executing command {}", fullCommand);
     boolean result = false;
@@ -114,7 +114,7 @@ public class OnPremiseExecutor implements Executor {
       }
     } finally {
       metrics.jobSubmission(arguments, "on-premise", result);
-      return result;
     }
+    return result;
   }
 }


### PR DESCRIPTION
This PR changes the gcloud execution to parse the output of the command based on the exit code. On error cases the stderr is read and logged, while on success case the output is parsed as JSON and returned. This will improve Spydra metrics as not all failures will be reported now as JSON parsing exceptions, which become fatal errors. After this PR is merged, the fatal errors due to gcloud command failing will become execution failures, like cluster creation or listing failure, instead.

Reading of the stderr leaves a door open for future to base our error metrics to actually parse the failure and report different types of errors. This PR will not add more error events yet.