### PR TITLE
Move heartbeat metadata to project level

### DIFF
--- a/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
+++ b/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
@@ -96,20 +96,30 @@ public class DataprocAPI {
     return success;
   }
 
-  public boolean updateMasterMetadata(SpydraArgument arguments, String key, String value)
-      throws IOException {
-    ImmutableMap<String, String> args = ImmutableMap.of(
-        SpydraArgument.OPTION_PROJECT, arguments.getCluster().getOptions().get(SpydraArgument.OPTION_PROJECT),
-        SpydraArgument.OPTION_ZONE, arguments.getCluster().getOptions().get(SpydraArgument.OPTION_ZONE));
+  public boolean updateProjectMetadata(
+      final SpydraArgument arguments, final String key, final String value) throws IOException {
     String project = arguments.getCluster().getOptions().get(SpydraArgument.OPTION_PROJECT);
-    String masterNode = gcloud.getMasterNode(project, arguments.getRegion(),
-        arguments.getCluster().getName());
+    ImmutableMap<String, String> args = ImmutableMap.of(SpydraArgument.OPTION_PROJECT, project);
 
     boolean success = false;
     try {
-      success = gcloud.updateMetadata(masterNode, args, key, value);
+      success = gcloud.updateMetadata(args, key, value);
     } finally {
       metrics.metadataUpdate(arguments, key, success);
+    }
+    return success;
+  }
+
+  public boolean removeProjectMetadata(final SpydraArgument arguments, final String key)
+      throws IOException {
+    String project = arguments.getCluster().getOptions().get(SpydraArgument.OPTION_PROJECT);
+    ImmutableMap<String, String> args = ImmutableMap.of(SpydraArgument.OPTION_PROJECT, project);
+
+    boolean success = false;
+    try {
+      success = gcloud.removeMetadata(args, key);
+    } finally {
+      metrics.metadataRemoval(arguments, key, success);
     }
     return success;
   }

--- a/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
+++ b/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
@@ -37,6 +37,7 @@ public class SpydraArgument {
   public static final String OPTION_REGION = "region";
   public static final String OPTION_ZONE = "zone";
   public static final String OPTION_METADATA = "metadata";
+  public static final String OPTION_METADATA_KEYS = "keys";
   public static final String OPTION_CLUSTER = "cluster";
   public static final String OPTION_INIT_ACTIONS = "initialization-actions";
   public static final String OPTION_SCOPES = "scopes";

--- a/metrics/src/main/java/com/spotify/spydra/metrics/Metrics.java
+++ b/metrics/src/main/java/com/spotify/spydra/metrics/Metrics.java
@@ -46,6 +46,8 @@ public abstract class Metrics {
 
   public abstract void metadataUpdate(SpydraArgument arguments, String key, boolean success);
 
+  public abstract void metadataRemoval(SpydraArgument arguments, String key, boolean success);
+
   public abstract void fatalError(SpydraArgument argument, Throwable throwable);
 
   public abstract void executionResult(SpydraArgument argument, boolean success);

--- a/metrics/src/main/java/com/spotify/spydra/metrics/impl/LoggingMetrics.java
+++ b/metrics/src/main/java/com/spotify/spydra/metrics/impl/LoggingMetrics.java
@@ -50,6 +50,11 @@ public class LoggingMetrics extends Metrics {
   }
 
   @Override
+  public void metadataRemoval(SpydraArgument arguments, String key, boolean success) {
+    LOGGER.info("Metadata with key " + key + "was removed with success=" + success);
+  }
+
+  @Override
   public void fatalError(SpydraArgument argument, Throwable throwable) {
     LOGGER.info("Fatal error was caught" + throwable.getCause());
   }

--- a/metrics/src/main/java/com/spotify/spydra/metrics/impl/LoggingMetrics.java
+++ b/metrics/src/main/java/com/spotify/spydra/metrics/impl/LoggingMetrics.java
@@ -46,12 +46,12 @@ public class LoggingMetrics extends Metrics {
 
   @Override
   public void metadataUpdate(SpydraArgument arguments, String key, boolean success) {
-    LOGGER.info("Metadata with key " + key + "was updated with success=" + success);
+    LOGGER.info("Metadata with key " + key + " was updated with success=" + success);
   }
 
   @Override
   public void metadataRemoval(SpydraArgument arguments, String key, boolean success) {
-    LOGGER.info("Metadata with key " + key + "was removed with success=" + success);
+    LOGGER.info("Metadata with key " + key + " was removed with success=" + success);
   }
 
   @Override

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
@@ -114,6 +114,7 @@ public class PoolingSubmitter extends DynamicSubmitter {
     // Label the pooled cluster with the client id. Unknown client ids all end up in their own pool.
     arguments.addOption(arguments.cluster.options, SpydraArgument.OPTION_LABELS,
         POOLED_CLUSTER_CLIENTID_LABEL + "=" + arguments.getClientId());
+    arguments.getCluster().setName(generateName());
     return super.acquireCluster(arguments, dataprocAPI);
   }
 


### PR DESCRIPTION
this PR solves #60 by moving heartbeat information from instance level metadata (which is set and updated on the master node instance and not updated for workers) to project level metadata which is shared and available for all instances within the cluster.