### PR TITLE
Optionally pass cluster name to jobs submitted to it

### DIFF
--- a/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
+++ b/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
@@ -83,6 +83,9 @@ public class SpydraArgument {
   // Optional Dataproc arguments
   public Optional<String> jobType = Optional.empty();
 
+  // Optional argument name for passing cluster to submitted jobs
+  public Optional<String> clusterArg = Optional.empty();
+
   public class Cluster {
     public Optional<String> name = Optional.empty();
     public Map<String, String> options = new HashMap<>();
@@ -355,6 +358,12 @@ public class SpydraArgument {
       merged.region = first.region;
     }
 
+    if (second.clusterArg.isPresent()) {
+      merged.clusterArg = second.clusterArg;
+    } else {
+      merged.clusterArg = first.clusterArg;
+    }
+
     return merged;
   }
 
@@ -480,6 +489,10 @@ public class SpydraArgument {
     return jobType.get();
   }
 
+  public String getClusterArg() {
+    return clusterArg.get();
+  }
+
   public Cluster getCluster() {
     return cluster;
   }
@@ -550,6 +563,10 @@ public class SpydraArgument {
 
   public void setJobType(String jobType) {
     this.jobType = Optional.of(jobType);
+  }
+
+  public void setClusterArg(String clusterArg) {
+    this.clusterArg = Optional.of(clusterArg);
   }
 
   public void setAutoScaler(AutoScaler autoScaler) {

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
@@ -55,6 +55,10 @@ public class Submitter {
 
   public boolean executeJob(SpydraArgument arguments) {
     try {
+      if (arguments.clusterArg.isPresent()) {
+        arguments.getSubmit().getJobArgs().add(arguments.getClusterArg());
+        arguments.getSubmit().getJobArgs().add(arguments.getCluster().getName());
+      }
       Executor executor = new ExecutorFactory().getExecutor(arguments);
       return executor.submit(arguments);
     } catch (IOException e) {

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliConsts.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliConsts.java
@@ -33,4 +33,5 @@ public class CliConsts {
   public final static String USERNAME_OPTION_NAME = "username";
   public final static String LOG_BUCKET_OPTION_NAME = "log-bucket";
   public final static String JOBNAME_OPTION_NAME = "job-name";
+  public final static String CLUSTER_ARG_NAME = "cluster-arg";
 }

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/SubmissionCliParser.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/SubmissionCliParser.java
@@ -51,6 +51,8 @@ public class SubmissionCliParser implements CliParser<SpydraArgument> {
             ", overwrites the configured ones if set"));
     options.addOption(CliHelper.createSingleOption(CliConsts.JOBNAME_OPTION_NAME,
         "job name, used as dataproc job id"));
+    options.addOption(CliHelper.createSingleOption(CliConsts.CLUSTER_ARG_NAME,
+        "name of argument passed to the job that will contain the cluster name"));
   }
 
   public SpydraArgument parse(String[] args) throws IOException {
@@ -93,6 +95,10 @@ public class SubmissionCliParser implements CliParser<SpydraArgument> {
 
     if (cmdLine.hasOption(SpydraArgument.OPTION_DRYRUN)) {
       spydraArgument.setDryRun(true);
+    }
+
+    if (cmdLine.hasOption(CliConsts.CLUSTER_ARG_NAME)) {
+      spydraArgument.setClusterArg(cmdLine.getOptionValue(CliConsts.CLUSTER_ARG_NAME));
     }
 
     List<String> jobArgs = new LinkedList<>(cmdLine.getArgList());

--- a/spydra/src/test/java/com/spotify/spydra/submitter/runner/SubmissionCliParserTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/runner/SubmissionCliParserTest.java
@@ -85,4 +85,14 @@ public class SubmissionCliParserTest {
     assertEquals("ck1=cv1,ck2=cv2", argument.cluster.options.get("labels"));
     assertEquals("sk1=sv1,sk2=sv2", argument.submit.options.get("labels"));
   }
+
+  @Test
+  public void testClusterArg() throws IOException {
+    SubmissionCliParser submissionCliParser = new SubmissionCliParser();
+
+    String[] cliArgs = {"submit", "--job-name", "my-job-123", "--cluster-arg", "--cluster.name"};
+    SpydraArgument args = submissionCliParser.parse(cliArgs);
+
+    assertEquals("--cluster.name", args.getClusterArg());
+  }
 }


### PR DESCRIPTION
This change set allows jobs to be aware of the cluster on which they are running.

This will allow jobs to access the web interfaces presented by the cluster which Spydra creates.

For example, HDFS is available inside the cluster at `hdfs://<cluster-name>-m`. We can add the following arguments to the invocation of Spydra: `--cluster-arg --cluster.name`
which will result in Spydra adding `--cluster.name spydra-<some-uuid>` to the job arguments at submission. Then we configure our job to connect to HDFS with `--hdfs.url hdfs://${cluster.name}-m` (parameter substitution is done by the jobs, not by Spydra).

Docs regarding cluster web interfaces are [here](https://cloud.google.com/dataproc/docs/concepts/accessing/cluster-web-interfaces).
