### PR TITLE
Update GCS connector from 1.6.0 to 1.6.3.

### DIFF
--- a/spydra/pom.xml
+++ b/spydra/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcs-connector</artifactId>
-      <version>1.6.0-hadoop2</version>
+      <version>1.6.3-hadoop2</version>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
This changes the GCS batch request endpoint to the new per-api endpoint
(https://github.com/GoogleCloudPlatform/bigdata-interop/blob/branch-1.6.x/gcs/CHANGES.txt),
as the old endpoint is being deprecated
(https://developers.googleblog.com/2018/03/discontinuing-support-for-json-rpc-and.html).