### PR TITLE
Use deterministic names for pooling clusters

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,6 +19,16 @@
       <artifactId>metrics</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+        <groupId>com.spotify.data.spydra</groupId>
+        <artifactId>metrics</artifactId>
+        <version>0.3.17-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify.data.spydra</groupId>
+      <artifactId>common</artifactId>
+      <version>0.3.17-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
+++ b/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.api;

--- a/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
+++ b/api/src/main/java/com/spotify/spydra/api/DataprocAPI.java
@@ -25,7 +25,7 @@ import com.spotify.spydra.metrics.Metrics;
 import com.spotify.spydra.metrics.MetricsFactory;
 import com.spotify.spydra.model.SpydraArgument;
 import java.io.IOException;
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -91,7 +91,7 @@ public class DataprocAPI {
     return success;
   }
 
-  public Collection<Cluster> listClusters(SpydraArgument arguments, Map<String, String> filters) throws IOException {
+  public List<Cluster> listClusters(SpydraArgument arguments, Map<String, String> filters) throws IOException {
     return gcloud.listClusters(arguments.cluster.getOptions().get("project"), arguments.getRegion(), filters);
   }
 }

--- a/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudClusterAlreadyExistsException.java
+++ b/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudClusterAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.spotify.spydra.api.gcloud;
+
+public class GcloudClusterAlreadyExistsException extends RuntimeException {
+
+  public GcloudClusterAlreadyExistsException(String msg) {
+    super(msg);
+  }
+}

--- a/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudClusterAlreadyExistsException.java
+++ b/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudClusterAlreadyExistsException.java
@@ -1,3 +1,22 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.spydra.api.gcloud;
 
 public class GcloudClusterAlreadyExistsException extends RuntimeException {

--- a/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudExecutor.java
+++ b/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudExecutor.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.api.gcloud;

--- a/api/src/main/java/com/spotify/spydra/api/model/Cluster.java
+++ b/api/src/main/java/com/spotify/spydra/api/model/Cluster.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.api.model;

--- a/api/src/main/java/com/spotify/spydra/api/process/ProcessHelper.java
+++ b/api/src/main/java/com/spotify/spydra/api/process/ProcessHelper.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.api.process;

--- a/common/src/main/java/com/spotify/spydra/model/ClusterType.java
+++ b/common/src/main/java/com/spotify/spydra/model/ClusterType.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.model;

--- a/common/src/main/java/com/spotify/spydra/model/JsonHelper.java
+++ b/common/src/main/java/com/spotify/spydra/model/JsonHelper.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.model;

--- a/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
+++ b/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.model;

--- a/common/src/main/java/com/spotify/spydra/util/GcpConfiguration.java
+++ b/common/src/main/java/com/spotify/spydra/util/GcpConfiguration.java
@@ -1,3 +1,22 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.spydra.util;
 
 import java.io.ByteArrayInputStream;

--- a/common/src/main/java/com/spotify/spydra/util/GcpUtils.java
+++ b/common/src/main/java/com/spotify/spydra/util/GcpUtils.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.util;

--- a/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
+++ b/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.util;

--- a/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
+++ b/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
@@ -116,8 +117,14 @@ public class SpydraArgumentUtil {
         base);
 
     GcpUtils gcpUtils = new GcpUtils();
-    gcpUtils.getUserId().ifPresent(userId ->
-      defaults.getCluster().getOptions().put(SpydraArgument.OPTION_ACCOUNT, userId));
+    gcpUtils.getUserId().ifPresent(userId -> {
+      final Map<String, String> options = defaults.getCluster().getOptions();
+
+      options.put(SpydraArgument.OPTION_ACCOUNT, userId);
+      // If we have json credentials on path, add the user as the service account user too
+      gcpUtils.getJsonCredentialsPath().ifPresent(
+          ignored -> options.put(SpydraArgument.OPTION_SERVICE_ACCOUNT, userId));
+    });
 
     gcpUtils.configureClusterProjectFromCredential(defaults);
     defaults.replacePlaceholders();

--- a/common/src/test/java/com/spotify/spydra/model/SpydraArgumentTest.java
+++ b/common/src/test/java/com/spotify/spydra/model/SpydraArgumentTest.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.model;

--- a/metrics/src/main/java/com/spotify/spydra/metrics/Metrics.java
+++ b/metrics/src/main/java/com/spotify/spydra/metrics/Metrics.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.metrics;

--- a/metrics/src/main/java/com/spotify/spydra/metrics/MetricsFactory.java
+++ b/metrics/src/main/java/com/spotify/spydra/metrics/MetricsFactory.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.metrics;

--- a/metrics/src/main/java/com/spotify/spydra/metrics/impl/LoggingMetrics.java
+++ b/metrics/src/main/java/com/spotify/spydra/metrics/impl/LoggingMetrics.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.metrics.impl;

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,12 @@
         <artifactId>json-path</artifactId>
         <version>2.2.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>value</artifactId>
+        <version>2.6.1</version>
+        <scope>provided</scope>
+      </dependency>
 
       <!-- Test dependencies -->
       <dependency>
@@ -299,6 +305,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-examples</artifactId>
         <version>${hadoop.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>java-hamcrest</artifactId>
+        <version>2.0.0.0</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,38 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>1.16</version>
+        <configuration>
+          <projectName>Spydra</projectName>
+          <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
+          <licenseName>apache_v2</licenseName>
+          <organizationName>Spotify AB</organizationName>
+          <inceptionYear>2016</inceptionYear>
+          <encoding>UTF-8</encoding>
+          <failOnMissingHeader>true</failOnMissingHeader>
+          <failOnNotUptodateHeader>true</failOnNotUptodateHeader>
+          <processStartTag>-\-\-</processStartTag>
+          <processEndTag>-/-/-</processEndTag>
+          <emptyLineAfterHeader>true</emptyLineAfterHeader>
+          <roots>
+            <root>src/main/java</root>
+            <root>src/test/java</root>
+          </roots>
+          <sectionDelimiter>--</sectionDelimiter>
+        </configuration>
+        <executions>
+          <execution>
+            <id>check-file-header</id>
+            <goals>
+              <goal>check-file-header</goal>
+            </goals>
+            <phase>process-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/spydra/pom.xml
+++ b/spydra/pom.xml
@@ -86,6 +86,15 @@
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>java-hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/spydra/src/main/java/com/spotify/spydra/historytools/DumpHistoryCliParser.java
+++ b/spydra/src/main/java/com/spotify/spydra/historytools/DumpHistoryCliParser.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools;

--- a/spydra/src/main/java/com/spotify/spydra/historytools/DumpLogsCliParser.java
+++ b/spydra/src/main/java/com/spotify/spydra/historytools/DumpLogsCliParser.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools;

--- a/spydra/src/main/java/com/spotify/spydra/historytools/HistoryLogUtils.java
+++ b/spydra/src/main/java/com/spotify/spydra/historytools/HistoryLogUtils.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools;

--- a/spydra/src/main/java/com/spotify/spydra/historytools/RemoteIteratorAdaptor.java
+++ b/spydra/src/main/java/com/spotify/spydra/historytools/RemoteIteratorAdaptor.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools;

--- a/spydra/src/main/java/com/spotify/spydra/historytools/RunJHSCliParser.java
+++ b/spydra/src/main/java/com/spotify/spydra/historytools/RunJHSCliParser.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools;

--- a/spydra/src/main/java/com/spotify/spydra/historytools/commands/DumpHistoryCommand.java
+++ b/spydra/src/main/java/com/spotify/spydra/historytools/commands/DumpHistoryCommand.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools.commands;

--- a/spydra/src/main/java/com/spotify/spydra/historytools/commands/DumpLogsCommand.java
+++ b/spydra/src/main/java/com/spotify/spydra/historytools/commands/DumpLogsCommand.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools.commands;

--- a/spydra/src/main/java/com/spotify/spydra/historytools/commands/RunJHSCommand.java
+++ b/spydra/src/main/java/com/spotify/spydra/historytools/commands/RunJHSCommand.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools.commands;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/ClusterPlacement.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/ClusterPlacement.java
@@ -1,0 +1,94 @@
+package com.spotify.spydra.submitter.api;
+
+
+import static com.spotify.spydra.submitter.api.PoolingSubmitter.SPYDRA_PLACEMENT_TOKEN_LABEL;
+import static com.spotify.spydra.submitter.api.PoolingSubmitter.SPYDRA_UNPLACED_TOKEN;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import com.spotify.spydra.api.model.Cluster;
+import com.spotify.spydra.model.SpydraArgument;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.immutables.value.Value;
+
+@Value.Style(
+    visibility = Value.Style.ImplementationVisibility.PRIVATE,
+    builderVisibility = Value.Style.BuilderVisibility.PACKAGE,
+    overshadowImplementation = true)
+@Value.Immutable
+abstract class ClusterPlacement {
+
+  abstract int clusterNumber();
+
+  abstract long clusterGeneration();
+
+  String token() {
+    return String.format("%s-%s", clusterNumber(), clusterGeneration());
+  }
+
+  static ClusterPlacement from(String token) {
+    String[] splits = token.split("-");
+    if (splits.length != 2) {
+      throw new IllegalArgumentException("Could not parse token: " + token);
+    }
+    try {
+      return new ClusterPlacementBuilder()
+          .clusterNumber(Integer.valueOf(splits[0]))
+          .clusterGeneration(Long.valueOf(splits[1]))
+          .build();
+    } catch (NumberFormatException nfe) {
+      throw new IllegalArgumentException("Could not parse token: " + token, nfe);
+    }
+  }
+
+  static List<ClusterPlacement> all(Supplier<Long> timeSource, SpydraArgument.Pooling pooling) {
+    return IntStream.range(0, pooling.getLimit())
+        .mapToObj(clusterNumber -> createClusterPlacement(timeSource, clusterNumber, pooling))
+        .collect(toList());
+  }
+
+  static ClusterPlacement createClusterPlacement(Supplier<Long> timeSource,
+                                                 int clusterNumber,
+                                                 SpydraArgument.Pooling pooling) {
+    int limit = pooling.getLimit();
+    long time = timeSource.get() / 1000;
+    long age = pooling.getMaxAge().getSeconds();
+
+    long generation = computeGeneration(clusterNumber, limit, time, age);
+
+    return new ClusterPlacementBuilder()
+        .clusterNumber(clusterNumber)
+        .clusterGeneration(generation)
+        .build();
+  }
+
+  static long computeGeneration(int clusterNumber, int limit, long time, long age) {
+    return (long) ((time - clusterNumber * (age / (float) limit)) / age);
+  }
+
+  private static ClusterPlacement placement(Cluster cluster) {
+    return from(cluster.labels.getOrDefault(SPYDRA_PLACEMENT_TOKEN_LABEL, SPYDRA_UNPLACED_TOKEN));
+  }
+
+  static List<Cluster> filterClusters(List<Cluster> clusters,
+                                      List<ClusterPlacement> allPlacements) {
+    Set<String> clusterPlacements = allPlacements.stream()
+        .map(ClusterPlacement::token)
+        .collect(toSet());
+
+    return clusters.stream()
+        .filter(cluster -> clusterPlacements.contains(placement(cluster).token()))
+        .collect(toList());
+  }
+
+  public Optional<Cluster> findIn(List<Cluster> clusters) {
+    return clusters.stream()
+        .filter(cluster -> this.equals(placement(cluster)))
+        .findFirst();
+  }
+
+}

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/ClusterPlacement.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/ClusterPlacement.java
@@ -73,11 +73,10 @@ abstract class ClusterPlacement {
   static ClusterPlacement createClusterPlacement(Supplier<Long> timeSource,
                                                  int clusterNumber,
                                                  SpydraArgument.Pooling pooling) {
-    int limit = pooling.getLimit();
     long time = timeSource.get() / 1000;
     long age = pooling.getMaxAge().getSeconds();
 
-    long generation = computeGeneration(clusterNumber, limit, time, age);
+    long generation = computeGeneration(time, age);
 
     return new ClusterPlacementBuilder()
         .clusterNumber(clusterNumber)
@@ -85,8 +84,8 @@ abstract class ClusterPlacement {
         .build();
   }
 
-  static long computeGeneration(int clusterNumber, int limit, long time, long age) {
-    return (long) ((time - clusterNumber * (age / (float) limit)) / age);
+  static long computeGeneration(long time, long age) {
+    return time / age;
   }
 
   private static ClusterPlacement placement(Cluster cluster) {

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/ClusterPlacement.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/ClusterPlacement.java
@@ -1,3 +1,22 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.spydra.submitter.api;
 
 

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/DefaultRandomPlacementGenerator.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/DefaultRandomPlacementGenerator.java
@@ -1,0 +1,12 @@
+package com.spotify.spydra.submitter.api;
+
+import java.util.List;
+import java.util.Random;
+
+public class DefaultRandomPlacementGenerator implements RandomPlacementGenerator {
+
+  @Override
+  public ClusterPlacement randomPlacement(final List<ClusterPlacement> placements) {
+    return placements.get(new Random().nextInt(placements.size()));
+  }
+}

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/DefaultRandomPlacementGenerator.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/DefaultRandomPlacementGenerator.java
@@ -1,3 +1,22 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.spydra.submitter.api;
 
 import java.util.List;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/DynamicSubmitter.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.api;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
@@ -1,3 +1,22 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.spydra.submitter.api;
 
 import static com.spotify.spydra.model.SpydraArgument.OPTIONS_FILTER_LABEL_PREFIX;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
@@ -1,20 +1,3 @@
-/*
- * Copyright 2017 Spotify AB.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package com.spotify.spydra.submitter.api;
 
 import static com.spotify.spydra.model.SpydraArgument.OPTIONS_FILTER_LABEL_PREFIX;
@@ -22,115 +5,138 @@ import static com.spotify.spydra.model.SpydraArgument.OPTIONS_FILTER_LABEL_PREFI
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.spydra.api.DataprocAPI;
+import com.spotify.spydra.api.gcloud.GcloudClusterAlreadyExistsException;
 import com.spotify.spydra.api.model.Cluster;
 import com.spotify.spydra.model.SpydraArgument;
 import java.io.IOException;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.Collection;
+import java.io.UncheckedIOException;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.function.Supplier;
 
+/**
+ * The PoolingSubmitter pools cluster in a rotating, fixed size pool.
+ * <p>
+ * The PoolingSubmitter addresses issues with the PoolingSubmitter significantly exceeding the
+ * configured limit. When running many clients simultaneously, they would all observe a free slot
+ * and create a cluster. Eventually these clusters exceeding the limit would be collected.
+ * For large amounts of clients, this would commonly lead to clusters in an ERROR state due to
+ * exceeding quota.
+ * <p>
+ * In this implementation we use an algorithm to createClusterPlacement clusters in slots according to a configured
+ * limit and maximum age at a certain time and placed into a random slot. The algorithm relies on
+ * the assumption that multiple clients creating a cluster with the same name fails for all but 1
+ * client. The failing clients will wait for a while and then select a cluster from the list of
+ * clusters available.
+ *
+ * The placement_token of a cluster is based two-part:<ul>
+ * <li>slot_number: a random number between 0 and Limit</li>
+ * <li>- time_derivative: {@code (Time - slot_number * (Age // Limit) ) // Age}</li>
+ * </ul> together these form a unique identifier for each clusters' lifetime.
+ * For each slot, it's cluster lifetime is offset by Age // Limit. This has as affect that
+ * the limit is exceeded by one cluster at a time which should become idle and thus collected before
+ * the next horde of clients come in. The algorithm is implemented in {@link ClusterPlacement#createClusterPlacement}.
+ * Example scenario's have been worked out in
+ * <a href="https://docs.google.com/spreadsheets/d/1Sfw_yxNSYJjHYtiHGQQf1ZHnNTqc7nGyXGGts_EaupM">a spreadsheet.</a>
+ */
 public class PoolingSubmitter extends DynamicSubmitter {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicSubmitter.class);
-
   @VisibleForTesting
-  static final String POOLED_CLUSTER_CLIENTID_LABEL = "spydra-cluster-pool-id";
+  static final String POOLED_CLUSTER_CLIENTID_LABEL =
+      "spydra-fixed-pooling-cluster-client-id";
+  public static final String SPYDRA_PLACEMENT_TOKEN_LABEL = "spydra-placement-token";
+  public static final String SPYDRA_UNPLACED_TOKEN = "unplaced";
+  private Supplier<Long> timeSource;
+  private final RandomPlacementGenerator randomPlacementGenerator;
 
-  public PoolingSubmitter() {
+  public PoolingSubmitter(Supplier<Long> timeSource,
+                          RandomPlacementGenerator randomPlacementGenerator) {
     super();
-  }
-
-  static final class Conditions {
-    static boolean isYoung(Cluster c, SpydraArgument arguments) {
-      return c.status.stateStartTime.plus(arguments.getPooling().getMaxAge())
-          .isAfter(ZonedDateTime.now(ZoneOffset.UTC));
-    }
-
-    public static boolean mayCreateMoreClusters(List<Cluster> filteredClusters,
-        SpydraArgument arguments) {
-      boolean may = filteredClusters.size() < arguments.getPooling().getLimit();
-      if (may) {
-        LOGGER.info(String.format("Got room for more clusters, %d out of %d.",
-            filteredClusters.size(), arguments.getPooling().getLimit()));
-      } else {
-        LOGGER.info(String.format("Should use a pooled cluster, have %d maximum %d clusters.",
-            filteredClusters.size(), arguments.getPooling().getLimit()));
-      }
-      return may;
-    }
+    this.timeSource = timeSource;
+    this.randomPlacementGenerator = randomPlacementGenerator;
   }
 
   @Override
   public boolean acquireCluster(SpydraArgument arguments, DataprocAPI dataprocAPI)
       throws IOException {
-    try {
-      //Have API filter on clusters that are active, are spydra clusters, and belong to the right pool
-      Map<String, String> clusterFilter = ImmutableMap.of(
-          "status.state", "ACTIVE",
-          OPTIONS_FILTER_LABEL_PREFIX + SPYDRA_CLUSTER_LABEL, "",
-          OPTIONS_FILTER_LABEL_PREFIX + POOLED_CLUSTER_CLIENTID_LABEL, arguments.getClientId()
-      );
-      Collection<Cluster> clusters = dataprocAPI.listClusters(arguments, clusterFilter);
-      LOGGER.info(
-          String.format("Found %d clusters in pool, finding suitable cluster to pool on", clusters.size()));
-      List<Cluster> filteredClusters = clusters.stream()
-          .filter(c -> Conditions.isYoung(c, arguments))
-          // Sort and limit to eventually over time arrive at the limit
-          .sorted(Comparator.comparing(c -> c.clusterName))
-          .limit(arguments.getPooling().getLimit())
-          .collect(Collectors.toList());
-      LOGGER.info(
-          String.format("After filtering conditions, %d cluster(s) remain", filteredClusters.size()));
-      if (Conditions.mayCreateMoreClusters(filteredClusters, arguments)) {
-        return newPooledCluster(arguments, dataprocAPI);
-      } else {
-        //TODO: TW do a weighted sample on metrics instead.
-        Collections.shuffle(filteredClusters);
-        Cluster cluster = filteredClusters.get(0);
-        mutateForCluster(arguments, cluster.clusterName, cluster.config.gceClusterConfig.zoneUri);
-        return true;
-      }
-    } catch (IOException e) {
-      LOGGER.warn("Failed to pool a cluster: ", e);
-    }
 
-    // All has failed us - try to create a cluster the good 'ol fashioned way.
-    return newPooledCluster(arguments, dataprocAPI);
+    List<Cluster> existingPoolableClusters =
+        dataprocAPI.listClusters(arguments, poolableClusterFilter(arguments.getClientId()));
+
+    List<ClusterPlacement> allPlacements =
+        ClusterPlacement.all(timeSource, arguments.getPooling());
+
+    List<Cluster> existingPlacementClusters =
+        ClusterPlacement.filterClusters(existingPoolableClusters, allPlacements);
+
+    ClusterPlacement randomPlacement = randomPlacementGenerator.randomPlacement(allPlacements);
+    Cluster cluster = randomPlacement.findIn(existingPlacementClusters)
+        .orElseGet(() -> {
+          try {
+            return createNewCluster(arguments, dataprocAPI, randomPlacement);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+
+    setTargetCluster(arguments, cluster.clusterName, cluster.config.gceClusterConfig.zoneUri);
+
+    return true;
   }
 
-  private boolean newPooledCluster(SpydraArgument arguments, DataprocAPI dataprocAPI)
+  private Cluster createNewCluster(SpydraArgument arguments,
+                                   DataprocAPI dataprocAPI,
+                                   ClusterPlacement placement)
       throws IOException {
     // Label the pooled cluster with the client id. Unknown client ids all end up in their own pool.
     arguments.addOption(arguments.cluster.options, SpydraArgument.OPTION_LABELS,
         POOLED_CLUSTER_CLIENTID_LABEL + "=" + arguments.getClientId());
-    arguments.getCluster().setName(generateName());
-    return super.acquireCluster(arguments, dataprocAPI);
+
+    arguments.addOption(arguments.cluster.options, SpydraArgument.OPTION_LABELS,
+        SPYDRA_PLACEMENT_TOKEN_LABEL + "=" + placement.token());
+
+    String clusterName = generateName(arguments.getClientId(), placement.token());
+    try {
+      return super.createNewCluster(arguments, dataprocAPI, () -> clusterName)
+          .orElseThrow(() -> new IOException("Failed to create cluster: " + clusterName));
+    } catch (GcloudClusterAlreadyExistsException e) {
+
+      List<Cluster> existingClusters =
+          dataprocAPI.listClusters(arguments, Collections.singletonMap("clusterName", clusterName));
+
+      if (existingClusters.size() != 1) {
+        throw new IllegalStateException(
+            "Expected a single cluster to exists. Cluster name:" + clusterName);
+      }
+
+      return existingClusters.get(0);
+    }
   }
 
+  public static String generateName(String clientId, String placementToken) {
+    return String.format("spydra-%s-%s", clientId, placementToken);
+  }
 
   @Override
   public boolean releaseCluster(SpydraArgument arguments, DataprocAPI dataprocAPI)
       throws IOException {
-    boolean shouldCollect;
-    // If we're pooling clusters the cluster will live long enough for history to be collected
-    shouldCollect = !arguments.isPoolingEnabled();
 
     Map<String, String> clusterFilter = ImmutableMap.of(
-            "status.state", "ERROR",
-            "clusterName", arguments.getCluster().getName(),
-            OPTIONS_FILTER_LABEL_PREFIX + SPYDRA_CLUSTER_LABEL, "",
-            OPTIONS_FILTER_LABEL_PREFIX + POOLED_CLUSTER_CLIENTID_LABEL, arguments.getClientId()
+        "status.state", "ERROR",
+        "clusterName", arguments.getCluster().getName()
     );
-    shouldCollect = shouldCollect || dataprocAPI.listClusters(arguments, clusterFilter).stream()
-            .findAny().map(cluster -> cluster.status.state.equals(Cluster.Status.ERROR)).orElse(false);
 
-    return !shouldCollect || super.releaseCluster(arguments, dataprocAPI);
+    boolean shouldRelease = dataprocAPI.listClusters(arguments, clusterFilter).stream()
+        .findAny().map(cluster -> cluster.status.state.equals(Cluster.Status.ERROR)).orElse(false);
+
+    return !shouldRelease || super.releaseCluster(arguments, dataprocAPI);
+  }
+
+  private static Map<String, String> poolableClusterFilter(String clientId) {
+    return ImmutableMap.of(
+        OPTIONS_FILTER_LABEL_PREFIX + SPYDRA_CLUSTER_LABEL, "",
+        OPTIONS_FILTER_LABEL_PREFIX + POOLED_CLUSTER_CLIENTID_LABEL, clientId
+    );
   }
 }

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/RandomPlacementGenerator.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/RandomPlacementGenerator.java
@@ -1,0 +1,8 @@
+package com.spotify.spydra.submitter.api;
+
+import java.util.List;
+
+public interface RandomPlacementGenerator {
+
+  ClusterPlacement randomPlacement(List<ClusterPlacement> placements);
+}

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/RandomPlacementGenerator.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/RandomPlacementGenerator.java
@@ -1,3 +1,22 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.spydra.submitter.api;
 
 import java.util.List;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.api;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
@@ -24,13 +24,17 @@ import com.spotify.spydra.submitter.executor.Executor;
 import com.spotify.spydra.submitter.executor.ExecutorFactory;
 import com.spotify.spydra.util.SpydraArgumentUtil;
 import java.io.IOException;
+import java.time.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Submitter {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(Submitter.class);
 
   private final Metrics metrics = MetricsFactory.getInstance();
+
+  private final static Clock clock = Clock.systemUTC();
 
   public static Submitter getSubmitter(SpydraArgument arguments) {
     SpydraArgumentUtil.checkRequiredArguments(arguments, SpydraArgumentUtil
@@ -43,7 +47,7 @@ public class Submitter {
       submitter = new Submitter();
     } else {
       if (arguments.isPoolingEnabled()) {
-        submitter = new PoolingSubmitter();
+        submitter = new PoolingSubmitter(clock::millis, new DefaultRandomPlacementGenerator());
       } else {
         submitter = new DynamicSubmitter();
       }

--- a/spydra/src/main/java/com/spotify/spydra/submitter/executor/DataprocExecutor.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/executor/DataprocExecutor.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.executor;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/executor/Executor.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/executor/Executor.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.executor;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/executor/ExecutorFactory.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/executor/ExecutorFactory.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.executor;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/executor/NullExecutor.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/executor/NullExecutor.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.executor;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/executor/OnPremiseExecutor.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/executor/OnPremiseExecutor.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.executor;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliConsts.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliConsts.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.runner;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliHelper.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliHelper.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.runner;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliParser.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliParser.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.runner;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/HelpParser.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/HelpParser.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.runner;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/Runner.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/Runner.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.runner;

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/SubmissionCliParser.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/SubmissionCliParser.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.runner;

--- a/spydra/src/test/java/com/google/auth/oauth2/GceHelper.java
+++ b/spydra/src/test/java/com/google/auth/oauth2/GceHelper.java
@@ -1,3 +1,22 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.google.auth.oauth2;
 
 public class GceHelper {

--- a/spydra/src/test/java/com/google/auth/oauth2/GceHelper.java
+++ b/spydra/src/test/java/com/google/auth/oauth2/GceHelper.java
@@ -1,0 +1,10 @@
+package com.google.auth.oauth2;
+
+public class GceHelper {
+
+  public static boolean runningOnComputeEngine() {
+
+    return ComputeEngineCredentials.runningOnComputeEngine(OAuth2Utils.HTTP_TRANSPORT_FACTORY,
+        DefaultCredentialsProvider.DEFAULT);
+  }
+}

--- a/spydra/src/test/java/com/spotify/spydra/CliTestHelpers.java
+++ b/spydra/src/test/java/com/spotify/spydra/CliTestHelpers.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra;

--- a/spydra/src/test/java/com/spotify/spydra/LifecycleIT.java
+++ b/spydra/src/test/java/com/spotify/spydra/LifecycleIT.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra;

--- a/spydra/src/test/java/com/spotify/spydra/LifecycleIT.java
+++ b/spydra/src/test/java/com/spotify/spydra/LifecycleIT.java
@@ -28,6 +28,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.dataproc.Dataproc;
 import com.google.api.services.dataproc.model.Cluster;
 import com.google.api.services.dataproc.model.ListClustersResponse;
+import com.google.auth.oauth2.GceHelper;
 import com.google.common.collect.Lists;
 import com.spotify.spydra.model.SpydraArgument;
 import com.spotify.spydra.submitter.api.Submitter;
@@ -43,6 +44,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +58,11 @@ public class LifecycleIT {
 
   @Test
   public void testLifecycle() throws Exception {
+    // The way that the haddop credentials provider is buggy as it tries to contact the metadata
+    // service in gcp if we use the default account
+    Assume.assumeTrue("Skipping lifecycle test, not running on gce and "
+                      + "GOOGLE_APPLICATION_CREDENTIALS not set",
+        hasApplicationJsonOrRunningOnGce());
     SpydraArgument testArgs = SpydraArgumentUtil.loadArguments("integration-test-config.json");
     SpydraArgument arguments = SpydraArgumentUtil
         .dataprocConfiguration(CLIENT_ID, testArgs.getLogBucket(), testArgs.getRegion());
@@ -85,6 +92,11 @@ public class LifecycleIT {
         "mapred:mapreduce.jobhistory.intermediate-done-dir"));
     LOGGER.info("Checking that we do not have any files in: " + intermediateUri);
     assertEquals(0, getFileCount(intermediateUri));
+  }
+
+  private boolean hasApplicationJsonOrRunningOnGce() {
+    return new GcpUtils().getJsonCredentialsPath().isPresent()
+           || GceHelper.runningOnComputeEngine();
   }
 
   private boolean isClusterCollected(SpydraArgument arguments)

--- a/spydra/src/test/java/com/spotify/spydra/historytools/DumpHistoryCliParserTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/historytools/DumpHistoryCliParserTest.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools;

--- a/spydra/src/test/java/com/spotify/spydra/historytools/DumpLogsCliParserTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/historytools/DumpLogsCliParserTest.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools;

--- a/spydra/src/test/java/com/spotify/spydra/historytools/HistoryLogUtilsTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/historytools/HistoryLogUtilsTest.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools;

--- a/spydra/src/test/java/com/spotify/spydra/historytools/RunJHSCliParserTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/historytools/RunJHSCliParserTest.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.historytools;

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/ClusterPlacementTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/ClusterPlacementTest.java
@@ -1,0 +1,108 @@
+package com.spotify.spydra.submitter.api;
+
+import static com.spotify.spydra.submitter.api.PoolingSubmitter.SPYDRA_PLACEMENT_TOKEN_LABEL;
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+import com.spotify.spydra.api.model.Cluster;
+import com.spotify.spydra.model.SpydraArgument;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class ClusterPlacementTest {
+
+  @Test
+  public void testComputeGeneration() {
+    assertEquals(ClusterPlacement.computeGeneration(0, 3, 0, 30), 0);
+    assertEquals(ClusterPlacement.computeGeneration(0, 3, 29, 30), 0);
+    assertEquals(ClusterPlacement.computeGeneration(0, 3, 30, 30), 1);
+
+    assertEquals(ClusterPlacement.computeGeneration(1, 3, 10, 30), 0);
+    assertEquals(ClusterPlacement.computeGeneration(1, 3, 39, 30), 0);
+    assertEquals(ClusterPlacement.computeGeneration(1, 3, 40, 30), 1);
+
+    assertEquals(ClusterPlacement.computeGeneration(2, 3, 20, 30), 0);
+    assertEquals(ClusterPlacement.computeGeneration(2, 3, 49, 30), 0);
+    assertEquals(ClusterPlacement.computeGeneration(2, 3, 50, 30), 1);
+  }
+
+  @Test
+  public void testAllPlacements() {
+    final SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
+    pooling.setLimit(3);
+    pooling.setMaxAge(Duration.ofSeconds(30));
+
+    final List<ClusterPlacement> all = ClusterPlacement.all(() -> 40000L, pooling);
+
+    final List<ClusterPlacement> expectedPlacements =
+        Arrays.asList(new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(1).build(),
+            new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(1).build(),
+            new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(0).build());
+
+    assertThat(all, hasSize(3));
+    assertThat(all, hasItems(new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(1).build(),
+        new ClusterPlacementBuilder().clusterNumber(1).clusterGeneration(1).build(),
+        new ClusterPlacementBuilder().clusterNumber(2).clusterGeneration(0).build()));
+  }
+
+  @Test
+  public void testFrom() {
+    ClusterPlacement clusterPlacement = ClusterPlacement.from("10-15");
+    assertThat(clusterPlacement.clusterNumber(), is(10));
+    assertThat(clusterPlacement.clusterGeneration(), is(15L));
+  }
+
+  @Test
+  public void testToken() {
+    final ClusterPlacement clusterPlacement =
+        new ClusterPlacementBuilder().clusterNumber(10).clusterGeneration(15L).build();
+    assertThat(clusterPlacement.token(), is("10-15"));
+  }
+
+  @Test
+  public void testFilterClusters() {
+
+    final List<ClusterPlacement> clusterPlacements =
+        Arrays.asList(new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(1).build(),
+            new ClusterPlacementBuilder().clusterNumber(1).clusterGeneration(1).build(),
+            new ClusterPlacementBuilder().clusterNumber(2).clusterGeneration(0).build());
+
+    final Cluster cluster1 = new Cluster();
+    cluster1.labels = Collections.singletonMap(SPYDRA_PLACEMENT_TOKEN_LABEL, "0-1");
+    final Cluster cluster2 = new Cluster();
+    cluster2.labels = Collections.singletonMap(SPYDRA_PLACEMENT_TOKEN_LABEL, "10-15");
+
+    final List<Cluster> filterClusters =
+        ClusterPlacement.filterClusters(Arrays.asList(cluster1, cluster2), clusterPlacements);
+
+    assertThat(filterClusters, hasSize(1));
+    assertThat(filterClusters, contains(cluster1));
+  }
+
+  @Test
+  public void testFindIn() {
+    final ClusterPlacement missingPlacement =
+        new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(0).build();
+    final ClusterPlacement existingPlacement =
+        new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(1).build();
+
+    final Cluster cluster1 = new Cluster();
+    cluster1.labels = Collections.singletonMap(SPYDRA_PLACEMENT_TOKEN_LABEL, "0-1");
+    final Cluster cluster2 = new Cluster();
+    cluster2.labels = Collections.singletonMap(SPYDRA_PLACEMENT_TOKEN_LABEL, "10-15");
+    final List<Cluster> clusters = Arrays.asList(cluster1, cluster2);
+
+    assertFalse(missingPlacement.findIn(clusters).isPresent());
+    assertTrue(existingPlacement.findIn(clusters).isPresent());
+    assertThat(existingPlacement.findIn(clusters).get(), is(cluster1));
+  }
+}

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/ClusterPlacementTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/ClusterPlacementTest.java
@@ -1,3 +1,22 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.spydra.submitter.api;
 
 import static com.spotify.spydra.submitter.api.PoolingSubmitter.SPYDRA_PLACEMENT_TOKEN_LABEL;

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/ClusterPlacementTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/ClusterPlacementTest.java
@@ -41,17 +41,9 @@ public class ClusterPlacementTest {
 
   @Test
   public void testComputeGeneration() {
-    assertEquals(ClusterPlacement.computeGeneration(0, 3, 0, 30), 0);
-    assertEquals(ClusterPlacement.computeGeneration(0, 3, 29, 30), 0);
-    assertEquals(ClusterPlacement.computeGeneration(0, 3, 30, 30), 1);
-
-    assertEquals(ClusterPlacement.computeGeneration(1, 3, 10, 30), 0);
-    assertEquals(ClusterPlacement.computeGeneration(1, 3, 39, 30), 0);
-    assertEquals(ClusterPlacement.computeGeneration(1, 3, 40, 30), 1);
-
-    assertEquals(ClusterPlacement.computeGeneration(2, 3, 20, 30), 0);
-    assertEquals(ClusterPlacement.computeGeneration(2, 3, 49, 30), 0);
-    assertEquals(ClusterPlacement.computeGeneration(2, 3, 50, 30), 1);
+    assertEquals(ClusterPlacement.computeGeneration(0, 30), 0);
+    assertEquals(ClusterPlacement.computeGeneration(30, 30), 1);
+    assertEquals(ClusterPlacement.computeGeneration(31, 30), 1);
   }
 
   @Test
@@ -62,15 +54,10 @@ public class ClusterPlacementTest {
 
     final List<ClusterPlacement> all = ClusterPlacement.all(() -> 40000L, pooling);
 
-    final List<ClusterPlacement> expectedPlacements =
-        Arrays.asList(new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(1).build(),
-            new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(1).build(),
-            new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(0).build());
-
     assertThat(all, hasSize(3));
     assertThat(all, hasItems(new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(1).build(),
         new ClusterPlacementBuilder().clusterNumber(1).clusterGeneration(1).build(),
-        new ClusterPlacementBuilder().clusterNumber(2).clusterGeneration(0).build()));
+        new ClusterPlacementBuilder().clusterNumber(2).clusterGeneration(1).build()));
   }
 
   @Test

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/DynamicSubmitterTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/DynamicSubmitterTest.java
@@ -1,17 +1,19 @@
 package com.spotify.spydra.submitter.api;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.spotify.spydra.api.DataprocAPI;
 import com.spotify.spydra.api.model.Cluster;
 import com.spotify.spydra.model.SpydraArgument;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,17 +41,35 @@ public class DynamicSubmitterTest {
   @Test
   public void releaseErrorCluster() throws Exception {
     ImmutableList<Cluster> clusters =
-            ImmutableList.of(PoolingTest.errorCluster(clientId), PoolingTest.errorCluster(clientId));
+            ImmutableList.of(errorCluster(clientId), errorCluster(clientId));
 
     SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
     arguments.setPooling(pooling);
     arguments.setClientId(clientId);
     arguments.cluster.setName(spydraClusterName);
 
-    when(dataprocAPI.listClusters(eq(arguments), anyMap()))
+    when(dataprocAPI.listClusters(eq(arguments), anyMapOf(String.class, String.class)))
             .thenReturn(clusters);
     when(dataprocAPI.deleteCluster(arguments)).thenReturn(true);
-    assertTrue("A broken cluster should be collected without problems.", dynamicSubmitter.releaseCluster(arguments, dataprocAPI));
+    assertTrue("A broken cluster should be collected without problems.",
+        dynamicSubmitter.releaseCluster(arguments, dataprocAPI));
     verify(dataprocAPI).deleteCluster(arguments);
+  }
+
+  private static Cluster perfectCluster(final String clientid) {
+    Cluster cluster = new Cluster();
+    cluster.clusterName = spydraClusterName;
+    Cluster.Status status = new Cluster.Status();
+    status.state = Cluster.Status.RUNNING;
+    status.stateStartTime = ZonedDateTime.now(ZoneOffset.UTC);
+    cluster.status = status;
+    cluster.labels = ImmutableMap.of(DynamicSubmitter.SPYDRA_CLUSTER_LABEL, "1");
+    return cluster;
+  }
+
+  private static Cluster errorCluster(final String clientid) {
+    Cluster cluster = perfectCluster(clientid);
+    cluster.status.state = Cluster.Status.ERROR;
+    return cluster;
   }
 }

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/DynamicSubmitterTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/DynamicSubmitterTest.java
@@ -1,3 +1,22 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.spydra.submitter.api;
 
 import static org.junit.Assert.assertTrue;

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
@@ -17,6 +17,17 @@
 
 package com.spotify.spydra.submitter.api;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.spydra.api.DataprocAPI;
@@ -31,22 +42,16 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyMap;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 @RunWith(Enclosed.class)
 public class PoolingTest {
+
   private static final String spydraClusterName = "spydra-uuid";
   private static final String nonSpydraClusterName = "not-a-spydra-cluster";
+  private static final String VALID_TOKEN_1 = "0-0";
+  private static final String VALID_TOKEN_2 = "1-0";
+  private static final Long NOW = Duration.ofMinutes(15).getSeconds() * 1000;
 
-  static Cluster perfectCluster(String clientid) {
+  static Cluster perfectCluster(final String clientid, final String token) {
     Cluster cluster = new Cluster();
     cluster.clusterName = spydraClusterName;
     Cluster.Status status = new Cluster.Status();
@@ -54,7 +59,8 @@ public class PoolingTest {
     status.stateStartTime = ZonedDateTime.now(ZoneOffset.UTC);
     cluster.status = status;
     cluster.labels = ImmutableMap.of(DynamicSubmitter.SPYDRA_CLUSTER_LABEL, "1",
-                                     PoolingSubmitter.POOLED_CLUSTER_CLIENTID_LABEL, clientid);
+        PoolingSubmitter.POOLED_CLUSTER_CLIENTID_LABEL, clientid,
+        PoolingSubmitter.SPYDRA_PLACEMENT_TOKEN_LABEL, token);
     cluster.config.gceClusterConfig.metadata.heartbeat =
         Optional.of(cluster.status.stateStartTime.plusMinutes(60));
     return cluster;
@@ -66,30 +72,20 @@ public class PoolingTest {
     cluster.clusterName = "not-a-spydra-cluster";
     Cluster.Status status = new Cluster.Status();
     cluster.labels = ImmutableMap.of(DynamicSubmitter.SPYDRA_CLUSTER_LABEL, "1",
-                                     PoolingSubmitter.POOLED_CLUSTER_CLIENTID_LABEL, clientid);
+        PoolingSubmitter.POOLED_CLUSTER_CLIENTID_LABEL, clientid);
     status.state = Cluster.Status.RUNNING;
     status.stateStartTime = ZonedDateTime.now(ZoneOffset.UTC);
     return cluster;
   }
 
   static Cluster creatingCluster(String clientid) {
-    Cluster cluster = perfectCluster(clientid);
+    Cluster cluster = perfectCluster(clientid, VALID_TOKEN_1);
     cluster.status.state = "CREATING";
     return cluster;
   }
 
-  static Cluster ancientCluster(String clientid) {
-    Cluster cluster = perfectCluster(clientid);
-
-    //Make cluster an hour older, and last heartbeat 30 minutes ago
-    cluster.status.stateStartTime = cluster.status.stateStartTime.minusMinutes(60);
-    cluster.config.gceClusterConfig.metadata.heartbeat =
-        Optional.of(cluster.status.stateStartTime.minusMinutes(30));
-    return cluster;
-  }
-
-  static Cluster errorCluster(String clientid) {
-    Cluster cluster = perfectCluster(clientid);
+  static Cluster errorCluster(final String clientid, final String token) {
+    Cluster cluster = perfectCluster(clientid, token);
     cluster.status.state = Cluster.Status.ERROR;
     return cluster;
   }
@@ -100,10 +96,14 @@ public class PoolingTest {
     DataprocAPI dataprocAPI;
     SpydraArgument arguments;
     String clientId;
+    private RandomPlacementGenerator randomPlacementGenerator;
 
     @Before
     public void before() {
-      poolingSubmitter = new PoolingSubmitter();
+      randomPlacementGenerator = mock(DefaultRandomPlacementGenerator.class);
+      when(randomPlacementGenerator.randomPlacement(anyListOf(ClusterPlacement.class)))
+          .thenCallRealMethod();
+      poolingSubmitter = new PoolingSubmitter(() -> NOW, randomPlacementGenerator);
       dataprocAPI = mock(DataprocAPI.class);
       arguments = new SpydraArgument();
       clientId = "my-client-id";
@@ -113,7 +113,8 @@ public class PoolingTest {
     public void acquirePooledCluster() throws Exception {
 
       ImmutableList<Cluster> clusters =
-          ImmutableList.of(perfectCluster(clientId), perfectCluster(clientId));
+          ImmutableList.of(perfectCluster(clientId, VALID_TOKEN_1),
+              perfectCluster(clientId, VALID_TOKEN_2));
 
       SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
       pooling.setLimit(2); // 2 perfectly suited clusters above!
@@ -121,16 +122,17 @@ public class PoolingTest {
       arguments.setClientId(clientId);
       arguments.setPooling(pooling);
 
-      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
+      when(dataprocAPI.listClusters(eq(arguments), anyMapOf(String.class, String.class)))
           .thenReturn(clusters);
       when(dataprocAPI.createCluster(arguments))
-          .thenReturn(Optional.of(new Cluster()));
+          .thenReturn(Optional.of(perfectCluster(clientId, VALID_TOKEN_1)));
 
       boolean result = poolingSubmitter.acquireCluster(arguments, dataprocAPI);
       assertTrue("Failed to acquire a cluster", result);
       verify(dataprocAPI, never()).createCluster(arguments);
 
-      assertTrue("A healthy cluster should be kept without problems.", poolingSubmitter.releaseCluster(arguments, dataprocAPI));
+      assertTrue("A healthy cluster should be kept without problems.",
+          poolingSubmitter.releaseCluster(arguments, dataprocAPI));
       verify(dataprocAPI, never()).deleteCluster(arguments);
 
     }
@@ -138,18 +140,19 @@ public class PoolingTest {
     @Test
     public void avoidAncientCluster() throws Exception {
       ImmutableList<Cluster> clusters =
-          ImmutableList.of(ancientCluster(clientId), ancientCluster(clientId));
+          ImmutableList.of(perfectCluster(clientId, VALID_TOKEN_1),
+              perfectCluster(clientId, VALID_TOKEN_2));
 
       SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
-      pooling.setLimit(2); // 2 reasonable but old clusters above. Pool is "full", but none usable.
-      pooling.setMaxAge(Duration.ofMinutes(30));
+      pooling.setLimit(1); // 2 reasonable but old clusters above. Pool is "full", but none usable.
+      pooling.setMaxAge(Duration.ofMinutes(10));
       arguments.setClientId(clientId);
       arguments.setPooling(pooling);
 
-      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
+      when(dataprocAPI.listClusters(eq(arguments), anyMapOf(String.class, String.class)))
           .thenReturn(clusters);
       when(dataprocAPI.createCluster(arguments))
-          .thenReturn(Optional.of(new Cluster()));
+          .thenReturn(Optional.of(perfectCluster(clientId, "0-3")));
 
       boolean result = poolingSubmitter.acquireCluster(arguments, dataprocAPI);
       assertTrue("Failed to acquire a cluster", result);
@@ -159,18 +162,27 @@ public class PoolingTest {
     @Test
     public void acquireNewCluster() throws Exception {
       ImmutableList<Cluster> clusters =
-          ImmutableList.of(perfectCluster(clientId), perfectCluster(clientId));
+          ImmutableList.of(perfectCluster(clientId, VALID_TOKEN_1));
 
       SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
-      pooling.setLimit(3); // 2 perfectly suited clusters above, so room for 1 more!
+      pooling.setLimit(2);
       pooling.setMaxAge(Duration.ofMinutes(30));
       arguments.setPooling(pooling);
       arguments.setClientId(clientId);
 
-      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
+      ClusterPlacement clusterPlacement = new ClusterPlacementBuilder()
+          .clusterNumber(1)
+          .clusterGeneration(0)
+          .build();
+
+      reset(randomPlacementGenerator);
+      when(randomPlacementGenerator.randomPlacement(anyListOf(ClusterPlacement.class)))
+          .thenReturn(clusterPlacement);
+
+      when(dataprocAPI.listClusters(eq(arguments), anyMapOf(String.class, String.class)))
           .thenReturn(clusters);
       when(dataprocAPI.createCluster(arguments))
-          .thenReturn(Optional.of(new Cluster()));
+          .thenReturn(Optional.of(perfectCluster(clientId, VALID_TOKEN_2)));
       boolean result = poolingSubmitter.acquireCluster(arguments, dataprocAPI);
       assertTrue("Failed to acquire a cluster", result);
       verify(dataprocAPI, times(1)).createCluster(arguments);
@@ -179,68 +191,44 @@ public class PoolingTest {
     @Test
     public void releaseCluster() throws Exception {
       ImmutableList<Cluster> clusters =
-          ImmutableList.of(perfectCluster(clientId), perfectCluster(clientId));
+          ImmutableList.of(perfectCluster(clientId, VALID_TOKEN_1),
+              perfectCluster(clientId, VALID_TOKEN_2));
 
       SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
+      pooling.setLimit(2);
+      pooling.setMaxAge(Duration.ofMinutes(30));
       arguments.setPooling(pooling);
       arguments.setClientId(clientId);
       arguments.cluster.setName(spydraClusterName);
 
-      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
-           .thenReturn(clusters);
-      assertTrue("A healthy cluster should be kept without problems.", poolingSubmitter.releaseCluster(arguments, dataprocAPI));
-      verify(dataprocAPI).listClusters(eq(arguments), anyMap());
+      when(dataprocAPI.listClusters(eq(arguments), anyMapOf(String.class, String.class)))
+          .thenReturn(clusters);
+      assertTrue("A healthy cluster should be kept without problems.",
+          poolingSubmitter.releaseCluster(arguments, dataprocAPI));
+      verify(dataprocAPI).listClusters(eq(arguments), anyMapOf(String.class, String.class));
       verify(dataprocAPI, never()).deleteCluster(arguments);
     }
 
     @Test
     public void releaseErrorCluster() throws Exception {
       ImmutableList<Cluster> clusters =
-              ImmutableList.of(errorCluster(clientId), errorCluster(clientId));
+          ImmutableList.of(errorCluster(clientId, VALID_TOKEN_1),
+              errorCluster(clientId, VALID_TOKEN_2));
 
-      SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
-      arguments.setPooling(pooling);
-      arguments.setClientId(clientId);
-      arguments.cluster.setName(spydraClusterName);
-
-      when(dataprocAPI.listClusters(eq(arguments), anyMap()))
-           .thenReturn(clusters);
-      when(dataprocAPI.deleteCluster(arguments)).thenReturn(true);
-      assertTrue("A broken cluster should be collected without problems.", poolingSubmitter.releaseCluster(arguments, dataprocAPI));
-      verify(dataprocAPI).listClusters(eq(arguments), anyMap());
-      verify(dataprocAPI).deleteCluster(arguments);
-    }
-  }
-
-  public static class PoolingConditionsTest {
-
-    @Test
-    public void isYoung() throws Exception {
-      String clientId = "some-client-id";
-      SpydraArgument arguments = new SpydraArgument();
-      SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
-      pooling.setMaxAge(Duration.ofMinutes(30));
-      arguments.setPooling(pooling);
-      arguments.setClientId(clientId);
-      assertTrue(PoolingSubmitter.Conditions.isYoung(perfectCluster(clientId), arguments));
-    }
-
-    @Test
-    public void mayCreateMoreClusters() throws Exception {
-      String myClientId="some-client-id";
-      ImmutableList<Cluster> clusters =
-          ImmutableList.of(perfectCluster(myClientId), perfectCluster(myClientId));
-      SpydraArgument arguments = new SpydraArgument();
       SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
       pooling.setLimit(2);
       pooling.setMaxAge(Duration.ofMinutes(30));
       arguments.setPooling(pooling);
-      arguments.setClientId(myClientId);
+      arguments.setClientId(clientId);
+      arguments.cluster.setName(spydraClusterName);
 
-      assertFalse(PoolingSubmitter.Conditions.mayCreateMoreClusters(clusters, arguments));
-
-      pooling.setLimit(3);
-      assertTrue(PoolingSubmitter.Conditions.mayCreateMoreClusters(clusters, arguments));
+      when(dataprocAPI.listClusters(eq(arguments), anyMapOf(String.class, String.class)))
+          .thenReturn(clusters);
+      when(dataprocAPI.deleteCluster(arguments)).thenReturn(true);
+      assertTrue("A broken cluster should be collected without problems.",
+          poolingSubmitter.releaseCluster(arguments, dataprocAPI));
+      verify(dataprocAPI).listClusters(eq(arguments), anyMapOf(String.class, String.class));
+      verify(dataprocAPI).deleteCluster(arguments);
     }
   }
 }

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/PoolingTest.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.api;

--- a/spydra/src/test/java/com/spotify/spydra/submitter/executor/OnPremiseExecutorTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/executor/OnPremiseExecutorTest.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.executor;

--- a/spydra/src/test/java/com/spotify/spydra/submitter/runner/RunnerTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/runner/RunnerTest.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.runner;

--- a/spydra/src/test/java/com/spotify/spydra/submitter/runner/SubmissionCliParserTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/runner/SubmissionCliParserTest.java
@@ -1,18 +1,21 @@
-/*
- * Copyright 2017 Spotify AB.
- *
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.spydra.submitter.runner;


### PR DESCRIPTION
This PR changes the way new clusters are created and jobs are assigned
to them in the poolable clusters in order to fix a concurrency problem
that made it create more clusters than the defined limit. The new
implementation uses deterministic names based of the current time to
decide the names of the clusters that should be used at a given moment
in time. Existing clusters than don't belong to them will be deleted
automatically after the max-idle time has passed, as no more jobs will
be assigned to them.
Special thanks to @Xeago for doing the initial implementation.