### PR TITLE
Add random offset to generation calculation

### DIFF
--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/ClusterPlacement.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/ClusterPlacement.java
@@ -29,6 +29,7 @@ import com.spotify.spydra.api.model.Cluster;
 import com.spotify.spydra.model.SpydraArgument;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
@@ -75,8 +76,9 @@ abstract class ClusterPlacement {
                                                  SpydraArgument.Pooling pooling) {
     long time = timeSource.get() / 1000;
     long age = pooling.getMaxAge().getSeconds();
+    long timeOffset = new Random(clusterNumber).longs(1, 0, age).findFirst().getAsLong();
 
-    long generation = computeGeneration(time, age);
+    long generation = computeGeneration(time + timeOffset, age);
 
     return new ClusterPlacementBuilder()
         .clusterNumber(clusterNumber)

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
@@ -56,8 +56,6 @@ import java.util.function.Supplier;
  * For each slot, it's cluster lifetime is offset by Age // Limit. This has as affect that
  * the limit is exceeded by one cluster at a time which should become idle and thus collected before
  * the next horde of clients come in. The algorithm is implemented in {@link ClusterPlacement#createClusterPlacement}.
- * Example scenario's have been worked out in
- * <a href="https://docs.google.com/spreadsheets/d/1Sfw_yxNSYJjHYtiHGQQf1ZHnNTqc7nGyXGGts_EaupM">a spreadsheet.</a>
  */
 public class PoolingSubmitter extends DynamicSubmitter {
 

--- a/spydra/src/test/java/com/spotify/spydra/submitter/api/ClusterPlacementTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/submitter/api/ClusterPlacementTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 import com.spotify.spydra.api.model.Cluster;
-import com.spotify.spydra.model.SpydraArgument;
+import com.spotify.spydra.model.SpydraArgument.Pooling;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,22 +40,38 @@ import org.junit.Test;
 public class ClusterPlacementTest {
 
   @Test
-  public void testComputeGeneration() {
-    assertEquals(ClusterPlacement.computeGeneration(0, 30), 0);
-    assertEquals(ClusterPlacement.computeGeneration(30, 30), 1);
-    assertEquals(ClusterPlacement.computeGeneration(31, 30), 1);
+  public void testClustereneration() {
+    // Random offset is 20 and 6 for clusterNumber 0 and 1 and age 30
+    final Pooling pooling = new Pooling();
+    pooling.setLimit(2);
+    pooling.setMaxAge(Duration.ofSeconds(30));
+    assertEquals(ClusterPlacement.createClusterPlacement(() -> 0L, 0, pooling)
+            .clusterGeneration(),0);
+    assertEquals(ClusterPlacement.createClusterPlacement(() -> 39000L, 0, pooling)
+        .clusterGeneration(), 1);
+    assertEquals(ClusterPlacement.createClusterPlacement(() -> 40000L, 0, pooling)
+        .clusterGeneration(), 2);
+
+    assertEquals(ClusterPlacement.createClusterPlacement(() -> 0L, 1, pooling)
+        .clusterGeneration(), 0);
+    assertEquals(ClusterPlacement.createClusterPlacement(() -> 23000L, 1, pooling)
+        .clusterGeneration(), 0);
+    assertEquals(ClusterPlacement.createClusterPlacement(() -> 24000L, 1, pooling)
+        .clusterGeneration(), 1);
   }
 
   @Test
   public void testAllPlacements() {
-    final SpydraArgument.Pooling pooling = new SpydraArgument.Pooling();
+    final Pooling pooling = new Pooling();
     pooling.setLimit(3);
     pooling.setMaxAge(Duration.ofSeconds(30));
 
+    // Random offsets are 20, 6 and 18 for the clusterNumbers 0, 1 and 2 and age 30
     final List<ClusterPlacement> all = ClusterPlacement.all(() -> 40000L, pooling);
 
     assertThat(all, hasSize(3));
-    assertThat(all, hasItems(new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(1).build(),
+    assertThat(all, hasItems(
+        new ClusterPlacementBuilder().clusterNumber(0).clusterGeneration(2).build(),
         new ClusterPlacementBuilder().clusterNumber(1).clusterGeneration(1).build(),
         new ClusterPlacementBuilder().clusterNumber(2).clusterGeneration(1).build()));
   }


### PR DESCRIPTION
This adds an offset to the formula that computes the generation. This is a random value between 0 and the max age of the cluster. The value is generated using the number of the cluster as seed to make it deterministic.

Adding this offset alleviates the situation where all the clusters of a generation are created at the same time having for some time twice the maximum number of clusters.