### PR TITLE
Avoiding duplicate jobs impl

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,6 +29,23 @@
       <artifactId>common</artifactId>
       <version>0.3.17-SNAPSHOT</version>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>java-hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/api/src/main/java/com/spotify/spydra/api/DataprocApi.java
+++ b/api/src/main/java/com/spotify/spydra/api/DataprocApi.java
@@ -23,11 +23,13 @@ package com.spotify.spydra.api;
 import com.google.common.annotations.VisibleForTesting;
 import com.spotify.spydra.api.gcloud.GcloudExecutor;
 import com.spotify.spydra.api.model.Cluster;
+import com.spotify.spydra.api.model.Job;
 import com.spotify.spydra.metrics.Metrics;
 import com.spotify.spydra.metrics.MetricsFactory;
 import com.spotify.spydra.model.SpydraArgument;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -101,4 +103,21 @@ public class DataprocApi {
     String region = arguments.getRegion();
     return gcloud.listClusters(project, region, filters);
   }
+
+  public List<Job> listJobs(SpydraArgument arguments)
+      throws IOException {
+    String project = arguments.cluster.getOptions().get("project");
+    String region = arguments.getRegion();
+    Map<String, String> labelItems = new HashMap<>();
+    Map<String, String> labels = arguments.getSubmit().getLabels();
+    labels.forEach((k,v) -> labelItems.put(String.format("labels.%s",k),v));
+
+    return gcloud.listJobs(project, region, labelItems);
+  }
+
+  public void waitJobForOutput(SpydraArgument arguments, String jobId) throws IOException {
+    String region = arguments.getRegion();
+    gcloud.waitForOutput(region,jobId);
+  }
+
 }

--- a/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudExecutor.java
+++ b/api/src/main/java/com/spotify/spydra/api/gcloud/GcloudExecutor.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.spotify.spydra.api.model.Cluster;
 import com.spotify.spydra.api.model.Job;
 import com.spotify.spydra.api.process.ProcessHelper;
+import com.spotify.spydra.api.process.ProcessResult;
+import com.spotify.spydra.api.process.ProcessService;
 import com.spotify.spydra.model.JsonHelper;
 import com.spotify.spydra.model.SpydraArgument;
 import com.spotify.spydra.util.GcpUtils;
@@ -46,12 +48,18 @@ public class GcloudExecutor {
 
   private static final String DEFAULT_GCLOUD_COMMAND = "gcloud";
 
+  private final ProcessService processService;
   private final String baseCommand;
 
   private boolean dryRun = false;
 
   public GcloudExecutor() {
+    this(new ProcessHelper());
+  }
+
+  public GcloudExecutor(ProcessService processService) {
     this.baseCommand = DEFAULT_GCLOUD_COMMAND;
+    this.processService = processService;
   }
 
   public Optional<Cluster> createCluster(String name, String region, Map<String, String> args)
@@ -60,12 +68,10 @@ public class GcloudExecutor {
     createOptions.put(SpydraArgument.OPTION_REGION, region);
     List<String> command = Arrays.asList(
         "--format=json", "beta", "dataproc", "clusters", "create", name);
-    StringBuilder outputBuilder = new StringBuilder();
-    boolean success = ProcessHelper.executeForOutput(
-        buildCommand(command, createOptions, Collections.emptyList()),
-        outputBuilder);
-    String output = outputBuilder.toString();
-    if (success) {
+    ProcessResult result = processService.executeForOutput(
+        buildCommand(command, createOptions, Collections.emptyList()));
+    String output = result.getOutput();
+    if (result.isSuccess()) {
       Cluster cluster = JsonHelper.objectMapper()
           .setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE)
           .readValue(output, Cluster.class);
@@ -144,7 +150,7 @@ public class GcloudExecutor {
       System.out.println(String.join(" ", command));
       return true;
     } else {
-      return ProcessHelper.executeCommand(command) == Shell.SUCCESS;
+      return processService.execute(command) == Shell.SUCCESS;
     }
   }
 
@@ -160,27 +166,26 @@ public class GcloudExecutor {
     this.dryRun = dryRun;
   }
 
-  public List<Job> listJobs(String project, String region, Map<String,String> filters)
+  public List<Job> listJobs(String project, String region, Map<String,String> filters,
+        Optional<Integer> limit, Optional<String> sortBy)
       throws IOException {
 
     final List<String> command = Arrays.asList("dataproc", "jobs", "list", "--format=json");
     Map<String, String> options = new HashMap<>();
     options.put(SpydraArgument.OPTION_PROJECT, project);
     options.put(SpydraArgument.OPTION_REGION, region);
+    limit.ifPresent(l -> options.put("limit", String.valueOf(l)));
+    sortBy.ifPresent(s -> options.put("sort-by", s));
 
     if (filters != null && !filters.isEmpty()) {
       String labelItems = SpydraArgumentUtil.joinFilters(filters);
       options.put(SpydraArgument.OPTIONS_FILTER, labelItems);
     }
 
-    StringBuilder outputBuilder = new StringBuilder();
-
-    boolean success = ProcessHelper.executeForOutput(
-            buildCommand(command, options, Collections.emptyList()),
-            outputBuilder
-    );
-    String output = outputBuilder.toString();
-    if (success) {
+    ProcessResult result = processService.executeForOutput(
+        buildCommand(command, options, Collections.emptyList()));
+    String output = result.getOutput();
+    if (result.isSuccess()) {
       Job[] jobs = JsonHelper.objectMapper()
               .setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE)
               .readValue(output, Job[].class);
@@ -205,13 +210,10 @@ public class GcloudExecutor {
       options.put(SpydraArgument.OPTIONS_FILTER, filterItems);
     }
 
-    StringBuilder outputBuilder = new StringBuilder();
-    boolean success = ProcessHelper.executeForOutput(
-        buildCommand(command, options, Collections.emptyList()),
-        outputBuilder
-    );
-    String output = outputBuilder.toString();
-    if (success) {
+    ProcessResult result = processService.executeForOutput(
+        buildCommand(command, options, Collections.emptyList()));
+    String output = result.getOutput();
+    if (result.isSuccess()) {
       Cluster[] clusters = JsonHelper.objectMapper()
              .setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE)
              .readValue(output, Cluster[].class);
@@ -223,18 +225,17 @@ public class GcloudExecutor {
     }
   }
 
-  public void waitForOutput(String region, String jobId) throws IOException {
+  public boolean waitForOutput(String region, String jobId) throws IOException {
     final List<String> command = Arrays.asList("dataproc", "jobs", "wait", jobId);
     Map<String, String> options = new HashMap<>();
     options.put(SpydraArgument.OPTION_REGION, region);
 
-    int exitCode = ProcessHelper.executeCommand(
-            buildCommand(command, options, Collections.emptyList())
-    );
+    int exitCode = processService.execute(buildCommand(command, options, Collections.emptyList()));
     if (exitCode != 0) {
-      LOGGER.error("Dataproc wait for job failed");
-      throw new IOException("Failed to wait for job. Gcloud call failed.");
+      LOGGER.error("Dataproc wait for job failed.");
+      return false;
+    } else {
+      return true;
     }
-
   }
 }

--- a/api/src/main/java/com/spotify/spydra/api/model/Job.java
+++ b/api/src/main/java/com/spotify/spydra/api/model/Job.java
@@ -22,8 +22,18 @@ package com.spotify.spydra.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.time.Instant;
+import java.util.Arrays;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Job {
+
+  public Job() { }
+
+  public Job(Reference reference, Status status) {
+    this.reference = reference;
+    this.status = status;
+  }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Status {
@@ -37,25 +47,44 @@ public class Job {
     public static final String DONE = "DONE";
     public static final String ERROR = "ERROR";
     public static final String ATTEMPT_FAILURE = "ATTEMPT_FAILURE";
+
     public String state;
+    public String stateStartTime;
+
+    public Status() { }
+
+    public Status(String state) {
+      this.state = state;
+    }
 
     public boolean isInProggress() {
-      return state.equals(PENDING) || state.equals(RUNNING) || state.equals(SETUP_DONE);
+      return Arrays
+          .asList(PENDING, RUNNING, SETUP_DONE, CANCEL_PENDING, CANCEL_STARTED)
+          .contains(state);
     }
 
     public boolean isDone() {
       return state.equals(DONE);
     }
 
-    public boolean isFailed() {
-      boolean isNotFailed = isInProggress() || isDone();
-      return !isNotFailed;
+    public String getStateStartTime() {
+      return stateStartTime;
     }
 
+    public Instant parseStateStartTime() {
+      return Instant.parse(stateStartTime);
+    }
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Reference {
+
+    public Reference() { }
+
+    public Reference(String jobId) {
+      this.jobId = jobId;
+    }
+
     public String jobId;
   }
 

--- a/api/src/main/java/com/spotify/spydra/api/model/Job.java
+++ b/api/src/main/java/com/spotify/spydra/api/model/Job.java
@@ -1,0 +1,65 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.spydra.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Job {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class Status {
+    public static final String STATE_UNSPECIFIED = "STATE_UNSPECIFIED";
+    public static final String PENDING = "PENDING";
+    public static final String SETUP_DONE = "SETUP_DONE";
+    public static final String RUNNING = "RUNNING";
+    public static final String CANCEL_PENDING = "CANCEL_PENDING";
+    public static final String CANCEL_STARTED = "CANCEL_STARTED";
+    public static final String CANCELLED = "CANCELLED";
+    public static final String DONE = "DONE";
+    public static final String ERROR = "ERROR";
+    public static final String ATTEMPT_FAILURE = "ATTEMPT_FAILURE";
+    public String state;
+
+    public boolean isInProggress() {
+      return state.equals(PENDING) || state.equals(RUNNING) || state.equals(SETUP_DONE);
+    }
+
+    public boolean isDone() {
+      return state.equals(DONE);
+    }
+
+    public boolean isFailed() {
+      boolean isNotFailed = isInProggress() || isDone();
+      return !isNotFailed;
+    }
+
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class Reference {
+    public String jobId;
+  }
+
+  public Reference reference;
+  public Status status;
+
+}

--- a/api/src/main/java/com/spotify/spydra/api/process/ProcessResult.java
+++ b/api/src/main/java/com/spotify/spydra/api/process/ProcessResult.java
@@ -18,23 +18,29 @@
  * -/-/-
  */
 
-package com.spotify.spydra.submitter.executor;
+package com.spotify.spydra.api.process;
 
-import com.spotify.spydra.api.DataprocApi;
-import com.spotify.spydra.model.SpydraArgument;
-import java.io.IOException;
+import jdk.nashorn.tools.Shell;
 
-public class DataprocExecutor implements Executor {
+public class ProcessResult {
 
-  private final DataprocApi dataprocApi;
+  private final int exitCode;
+  private final String output;
 
-  public DataprocExecutor(DataprocApi dataprocApi) {
-    this.dataprocApi = dataprocApi;
+  public ProcessResult(int exitCode, String output) {
+    this.exitCode = exitCode;
+    this.output = output;
   }
 
-  @Override
-  public boolean submit(SpydraArgument arguments) throws IOException {
-    dataprocApi.dryRun(arguments.isDryRun());
-    return dataprocApi.submit(arguments);
+  public int getExitCode() {
+    return exitCode;
+  }
+
+  public String getOutput() {
+    return output;
+  }
+
+  public boolean isSuccess() {
+    return exitCode == Shell.SUCCESS;
   }
 }

--- a/api/src/main/java/com/spotify/spydra/api/process/ProcessService.java
+++ b/api/src/main/java/com/spotify/spydra/api/process/ProcessService.java
@@ -18,23 +18,14 @@
  * -/-/-
  */
 
-package com.spotify.spydra.submitter.executor;
+package com.spotify.spydra.api.process;
 
-import com.spotify.spydra.api.DataprocApi;
-import com.spotify.spydra.model.SpydraArgument;
 import java.io.IOException;
+import java.util.List;
 
-public class DataprocExecutor implements Executor {
+public interface ProcessService {
 
-  private final DataprocApi dataprocApi;
+  public int execute(List<String> command) throws IOException;
 
-  public DataprocExecutor(DataprocApi dataprocApi) {
-    this.dataprocApi = dataprocApi;
-  }
-
-  @Override
-  public boolean submit(SpydraArgument arguments) throws IOException {
-    dataprocApi.dryRun(arguments.isDryRun());
-    return dataprocApi.submit(arguments);
-  }
+  public ProcessResult executeForOutput(List<String> command) throws IOException;
 }

--- a/api/src/test/java/com/spotify/spydra/api/DataprocApiTest.java
+++ b/api/src/test/java/com/spotify/spydra/api/DataprocApiTest.java
@@ -1,0 +1,143 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.spydra.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.spotify.spydra.api.gcloud.GcloudExecutor;
+import com.spotify.spydra.api.model.Job;
+import com.spotify.spydra.api.process.ProcessResult;
+import com.spotify.spydra.api.process.ProcessService;
+import com.spotify.spydra.metrics.MetricsFactory;
+import com.spotify.spydra.model.SpydraArgument;
+import com.spotify.spydra.model.SpydraArgument.Cluster;
+import com.spotify.spydra.model.SpydraArgument.Submit;
+
+import static com.spotify.spydra.api.TestUtils.*;
+
+import static org.mockito.Mockito.*;
+
+import static org.junit.Assert.*;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+public class DataprocApiTest {
+
+  private DataprocApi api;
+  private GcloudExecutor gcloudExecutor;
+  private ProcessService processService;
+  private SpydraArgument arguments;
+
+  @Before
+  public void setUp() {
+    processService = mock(ProcessService.class);
+    gcloudExecutor = new GcloudExecutor(processService);
+    api = new DataprocApi(gcloudExecutor, MetricsFactory.getInstance(), Clock.systemUTC());
+    arguments = spydraArguments("example-project", "us-central1");
+  }
+
+  @Test
+  public void testFindJobToResume() throws Exception {
+
+    ArgumentCaptor<List<String>> commandCaptor = listArgumentCaptor(String.class);
+
+    when(processService.executeForOutput(commandCaptor.capture()))
+      .thenReturn(new ProcessResult(0, fromResource("/job-single.json")));
+
+    Optional<Job> maybeJob = api.findJobToResume(arguments);
+
+    assertTrue(maybeJob.isPresent());
+
+    List<String> command = commandCaptor.getValue();
+
+    assertTrue(command.contains("--region=us-central1"));
+    assertTrue(command.contains("--project=example-project"));
+    assertTrue(command.contains("--filter=labels.spydra-dedup-id=job1"));
+    assertTrue(command.contains("--limit=1"));
+    assertTrue(command.contains("--sort-by=~status.stateStartTime"));
+  }
+
+  @Test
+  public void testFIndJobToResumeWithoutTimeLimit() throws Exception {
+
+    when(processService.executeForOutput(anyListOf(String.class)))
+      .thenReturn(new ProcessResult(0, fromResource("/job-single.json")));
+
+    Optional<Job> maybeJob = api.findJobToResume(arguments);
+
+    assertTrue(maybeJob.isPresent());
+  }
+
+  @Test
+  public void testJobToResumeIsWithinTimeLimit() throws Exception {
+
+    Instant currentTime = Instant.parse("2018-08-30T12:00:00.000Z");
+    api = new DataprocApi(gcloudExecutor, MetricsFactory.getInstance(), Clock.fixed(currentTime, ZoneOffset.UTC));
+
+    when(processService.executeForOutput(anyListOf(String.class)))
+      .thenReturn(new ProcessResult(0, fromResource("/job-single.json")));
+
+    arguments.deduplicationMaxAge = Optional.of(Duration.of(6, ChronoUnit.HOURS).getSeconds());
+
+    Optional<Job> maybeJob = api.findJobToResume(arguments);
+
+    assertTrue(maybeJob.isPresent());
+  }
+
+  @Test
+  public void testJobToResumeIsTooOld() throws Exception {
+
+    Instant currentTime = Instant.parse("2018-08-30T13:00:00.000Z");
+    api = new DataprocApi(gcloudExecutor, MetricsFactory.getInstance(), Clock.fixed(currentTime, ZoneOffset.UTC));
+
+    when(processService.executeForOutput(anyListOf(String.class)))
+      .thenReturn(new ProcessResult(0, fromResource("/job-single.json")));
+
+    arguments.deduplicationMaxAge = Optional.of(Duration.of(6, ChronoUnit.HOURS).getSeconds());
+
+    Optional<Job> maybeJob = api.findJobToResume(arguments);
+
+    assertFalse(maybeJob.isPresent());
+  }
+
+  private SpydraArgument spydraArguments(String project, String region) {
+    SpydraArgument arguments = new SpydraArgument();
+
+    Cluster cluster = arguments.new Cluster();
+    cluster.project(project);
+    arguments.setCluster(cluster);
+
+    Submit submit = arguments.new Submit();
+    submit.setLabels(SpydraArgument.OPTIONS_DEDUPLICATING_LABEL + "=job1");
+    arguments.setSubmit(submit);
+
+    arguments.setRegion(region);
+    return arguments;
+  }
+}

--- a/api/src/test/java/com/spotify/spydra/api/TestUtils.java
+++ b/api/src/test/java/com/spotify/spydra/api/TestUtils.java
@@ -1,0 +1,58 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.spydra.api;
+
+import static org.junit.Assert.assertFalse;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+
+import org.mockito.ArgumentCaptor;
+
+public abstract class TestUtils {
+
+  private TestUtils() { }
+
+  public static void assertNoneStartsWith(List<String> command, String prefix) {
+    assertFalse(command.stream().anyMatch(s -> s.startsWith(prefix)));
+  }
+
+  public static String fromResource(String resource) {
+    char[] buffer = new char[1024];
+    StringBuilder sb = new StringBuilder();
+    int len = 0;
+    try (BufferedReader r = new BufferedReader(new InputStreamReader(TestUtils.class.getResourceAsStream(resource)))) {
+      while ((len = r.read(buffer)) >= 0) {
+        sb.append(buffer, 0, len);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return sb.toString();
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public static <T> ArgumentCaptor<List<T>> listArgumentCaptor(Class<T> type) {
+    return ArgumentCaptor.forClass((Class)List.class);
+  }
+}

--- a/api/src/test/java/com/spotify/spydra/api/gcloud/GcloudExecutorTest.java
+++ b/api/src/test/java/com/spotify/spydra/api/gcloud/GcloudExecutorTest.java
@@ -1,0 +1,100 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.spydra.api.gcloud;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.spotify.spydra.api.model.Job;
+import com.spotify.spydra.api.process.ProcessResult;
+import com.spotify.spydra.api.process.ProcessService;
+
+import static com.spotify.spydra.api.TestUtils.*;
+
+import static org.mockito.Mockito.*;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class GcloudExecutorTest {
+
+  private GcloudExecutor gcloudExecutor;
+  private ProcessService processService;
+
+  @Before
+  public void setUp() {
+    processService = mock(ProcessService.class);
+    gcloudExecutor = new GcloudExecutor(processService);
+  }
+
+  @Test
+  public void testListJobsWithOptinalArgs() throws IOException {
+
+    ArgumentCaptor<List<String>> commandCaptor = listArgumentCaptor(String.class);
+
+    when(processService.executeForOutput(commandCaptor.capture()))
+      .thenReturn(new ProcessResult(0, fromResource("/job-list.json")));
+
+    List<Job> jobs = gcloudExecutor.listJobs("<project>", "<region>",
+        Collections.singletonMap("<filterkey>", "<filtervalue>"),
+        Optional.of(99),
+        Optional.of("<sortby>"));
+
+    assertEquals(2,  jobs.size());
+
+    List<String> command = commandCaptor.getValue();
+    assertTrue(command.contains("--region=<region>"));
+    assertTrue(command.contains("--project=<project>"));
+    assertTrue(command.contains("--filter=<filterkey>=<filtervalue>"));
+    assertTrue(command.contains("--limit=99"));
+    assertTrue(command.contains("--sort-by=<sortby>"));
+  }
+
+  @Test
+  public void testListJobsWithoutOptionalArgs() throws IOException {
+
+    ArgumentCaptor<List<String>> commandCaptor = listArgumentCaptor(String.class);
+
+    when(processService.executeForOutput(commandCaptor.capture()))
+      .thenReturn(new ProcessResult(0, fromResource("/job-list.json")));
+
+    List<Job> jobs = gcloudExecutor.listJobs("<project>", "<region>",
+        Collections.emptyMap(),
+        Optional.empty(),
+        Optional.empty());
+
+    assertEquals(2,  jobs.size());
+
+    List<String> command = commandCaptor.getValue();
+    assertTrue(command.contains("--region=<region>"));
+    assertTrue(command.contains("--project=<project>"));
+    assertNoneStartsWith(command, "--filter");
+    assertNoneStartsWith(command, "--limit");
+    assertNoneStartsWith(command, "--sort-by");
+  }
+}
+
+

--- a/api/src/test/resources/job-list.json
+++ b/api/src/test/resources/job-list.json
@@ -1,0 +1,110 @@
+[
+    {
+        "driverControlFilesUri": "gs://bucket/path1",
+        "driverOutputResourceUri": "gs://bucket/path1",
+        "hadoopJob": {
+            "args": [
+                "arg1",
+                "arg2"
+            ],
+            "jarFileUris": [
+                "gs://bucket/jarfile.jar"
+            ],
+            "loggingConfig": {},
+            "mainClass": "com.example.Main"
+        },
+        "labels": {
+            "spydra-dedup-id":"job-1"
+        },
+        "placement": {
+            "clusterName": "spydra-1234",
+            "clusterUuid": "1234"
+        },
+        "reference": {
+            "jobId": "job-1",
+            "projectId": "com.example.project"
+        },
+        "status": {
+            "state": "DONE",
+            "stateStartTime": "2018-08-30T06:14:25.823Z"
+        },
+        "statusHistory": [
+            {
+                "state": "PENDING",
+                "stateStartTime": "2018-08-30T00:06:03.889Z"
+            },
+            {
+                "state": "SETUP_DONE",
+                "stateStartTime": "2018-08-30T00:06:03.935Z"
+            },
+            {
+                "details": "Agent reported job success",
+                "state": "RUNNING",
+                "stateStartTime": "2018-08-30T00:06:04.081Z"
+            }
+        ],
+        "type": "hadoop",
+        "yarnApplications": [
+            {
+                "name": "yarn job 1",
+                "progress": 1.0,
+                "state": "FINISHED",
+                "trackingUrl": "http://tracking-url/1"
+            }
+        ]
+    },
+    {
+        "driverControlFilesUri": "gs://bucket/path2",
+        "driverOutputResourceUri": "gs://bucket/path2",
+        "hadoopJob": {
+            "args": [
+                "arg1",
+                "arg2"
+            ],
+            "jarFileUris": [
+                "gs://bucket/jarfile.jar"
+            ],
+            "loggingConfig": {},
+            "mainClass": "com.example.Main"
+        },
+        "labels": {
+            "spydra-dedup-id":"job-2"
+        },
+        "placement": {
+            "clusterName": "spydra-5678",
+            "clusterUuid": "5678"
+        },
+        "reference": {
+            "jobId": "job-2",
+            "projectId": "com.example.project"
+        },
+        "status": {
+            "state": "DONE",
+            "stateStartTime": "2018-08-30T07:14:25.823Z"
+        },
+        "statusHistory": [
+            {
+                "state": "PENDING",
+                "stateStartTime": "2018-08-30T01:06:03.889Z"
+            },
+            {
+                "state": "SETUP_DONE",
+                "stateStartTime": "2018-08-30T01:06:03.935Z"
+            },
+            {
+                "details": "Agent reported job success",
+                "state": "RUNNING",
+                "stateStartTime": "2018-08-30T01:06:04.081Z"
+            }
+        ],
+        "type": "hadoop",
+        "yarnApplications": [
+            {
+                "name": "yarn job 2",
+                "progress": 1.0,
+                "state": "FINISHED",
+                "trackingUrl": "http://tracking-url/2"
+            }
+        ]
+    }
+]

--- a/api/src/test/resources/job-single.json
+++ b/api/src/test/resources/job-single.json
@@ -1,0 +1,57 @@
+[
+    {
+        "driverControlFilesUri": "gs://bucket/path1",
+        "driverOutputResourceUri": "gs://bucket/path1",
+        "hadoopJob": {
+            "args": [
+                "arg1",
+                "arg2"
+            ],
+            "jarFileUris": [
+                "gs://bucket/jarfile.jar"
+            ],
+            "loggingConfig": {},
+            "mainClass": "com.example.Main"
+        },
+        "labels": {
+            "spydra-dedup-id":"job-1"
+        },
+        "placement": {
+            "clusterName": "spydra-1234",
+            "clusterUuid": "1234"
+        },
+        "reference": {
+            "jobId": "job-1",
+            "projectId": "com.example.project"
+        },
+        "status": {
+            "state": "DONE",
+            "stateStartTime": "2018-08-30T06:14:25.823Z"
+        },
+        "statusHistory": [
+            {
+                "state": "PENDING",
+                "stateStartTime": "2018-08-30T00:06:03.889Z"
+            },
+            {
+                "state": "SETUP_DONE",
+                "stateStartTime": "2018-08-30T00:06:03.935Z"
+            },
+            {
+                "details": "Agent reported job success",
+                "state": "RUNNING",
+                "stateStartTime": "2018-08-30T00:06:04.081Z"
+            }
+        ],
+        "type": "hadoop",
+        "yarnApplications": [
+            {
+                "name": "yarn job 1",
+                "progress": 1.0,
+                "state": "FINISHED",
+                "trackingUrl": "http://tracking-url/1"
+            }
+        ]
+    }
+]
+

--- a/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
+++ b/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
@@ -21,6 +21,7 @@
 package com.spotify.spydra.model;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -56,7 +57,7 @@ public class SpydraArgument {
   public static final String OPTION_MAX_IDLE = "max-idle";
   public static final String OPTIONS_FILTER = "filter";
   public static final String OPTIONS_FILTER_LABEL_PREFIX = "labels.";
-
+  public static final String OPTIONS_DEDUPLICATING_LABEL = "spydra-dedup-id";
 
   public static final String JOB_TYPE_HADOOP = "hadoop";
   public static final String JOB_TYPE_PYSPARK = "pyspark";
@@ -66,6 +67,7 @@ public class SpydraArgument {
   public static final String UUID_PLACEHOLDER = "${UUID}";
 
   public static final String OPTION_DRYRUN = "dry-run";
+
 
   // Required arguments
   public Optional<String> clientId = Optional.empty();
@@ -79,6 +81,7 @@ public class SpydraArgument {
   public Optional<Boolean> dryRun = Optional.of(false);
   public Optional<AutoScaler> autoScaler = Optional.empty();
   public Optional<Pooling> pooling = Optional.empty();
+  public Optional<Long> deduplicationMaxAge = Optional.empty();
 
   // Dataproc arguments
   public Cluster cluster = new Cluster();
@@ -326,6 +329,12 @@ public class SpydraArgument {
       merged.dryRun = first.dryRun;
     }
 
+    if (second.deduplicationMaxAge.isPresent()) {
+      merged.deduplicationMaxAge = second.deduplicationMaxAge;
+    } else {
+      merged.deduplicationMaxAge = first.deduplicationMaxAge;
+    }
+
     if (second.jobType.isPresent()) {
       merged.jobType = second.jobType;
     } else {
@@ -563,6 +572,14 @@ public class SpydraArgument {
 
   public void setDryRun(Boolean dryRun) {
     this.dryRun = Optional.of(dryRun);
+  }
+
+  public void setDeduplicationMaxAge(long maxAge) {
+    this.deduplicationMaxAge = Optional.of(maxAge);
+  }
+
+  public Optional<Duration> deduplicationMaxAge() {
+    return deduplicationMaxAge.map(ms -> Duration.of(ms, ChronoUnit.SECONDS));
   }
 
   public void setCluster(Cluster cluster) {

--- a/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
+++ b/common/src/main/java/com/spotify/spydra/model/SpydraArgument.java
@@ -47,7 +47,8 @@ public class SpydraArgument {
   public static final String OPTION_WORKER_MACHINE_TYPE = "worker-machine-type";
   public static final String OPTION_MASTER_MACHINE_TYPE = "master-machine-type";
   public static final String OPTION_NUM_WORKERS = "num-workers";
-  public static final String OPTION_LABELS = "labels";
+  public static final String OPTION_CLUSTER_LABELS = "labels";
+  public static final String OPTION_JOB_LABELS = "labels";
   public static final String OPTION_TAGS = "tags";
   public static final String OPTION_ACCOUNT = "account";
   public static final String OPTION_SERVICE_ACCOUNT = "service-account";
@@ -158,6 +159,10 @@ public class SpydraArgument {
       this.jobArgs = Optional.of(jobArgs);
     }
 
+    public Map<String, String> getLabels() {
+      return parseLabels(options);
+    }
+
     // Below are convenience functions when using this from the Java API.
 
     public void jar(String mainJar) {
@@ -185,6 +190,11 @@ public class SpydraArgument {
       options.merge(OPTION_PROPERTIES, property,
           (oldProperties, newProperty) -> oldProperties + "," + newProperty);
     }
+
+    public void setLabels(String labelsOption) {
+      options.put(OPTION_JOB_LABELS, labelsOption);
+    }
+
   }
 
   public static class AutoScaler {
@@ -431,7 +441,19 @@ public class SpydraArgument {
         properties.put(split[0], split[1]);
       }
     }
+
     return properties;
+  }
+
+  private static Map<String,String> parseLabels(Map<String,String> options) {
+    Map<String, String> labels = new HashMap<>();
+    if (options.containsKey(OPTION_JOB_LABELS)) {
+      for (String labelValue : options.get(OPTION_JOB_LABELS).split(",")) {
+        String[] split = labelValue.split("=");
+        labels.put(split[0].trim(), split[1].trim());
+      }
+    }
+    return labels;
   }
 
   // Special treatment for options that allow a list of values
@@ -440,7 +462,7 @@ public class SpydraArgument {
       case OPTION_INIT_ACTIONS:
       case OPTION_SCOPES:
       case OPTION_METADATA:
-      case OPTION_LABELS:
+      case OPTION_CLUSTER_LABELS:
       case OPTION_TAGS:
       case OPTION_PROPERTIES:
       case OPTION_JARS:

--- a/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
+++ b/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
@@ -36,6 +36,7 @@ import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -252,4 +253,17 @@ public class SpydraArgumentUtil {
   public static boolean isStaticInvocation(SpydraArgument arguments) {
     return arguments.getSubmit().getOptions().containsKey(OPTION_CLUSTER);
   }
+
+  public static String joinFilters(Map<String,String> filters) {
+    StringJoiner filterItems = new StringJoiner(" AND ");
+    filters.forEach((key, value) -> {
+      //Allows for label filters to not specify a value to match "anything" (just check if exists)
+      if (value == null || value.isEmpty()) {
+        value = "*";
+      }
+      filterItems.add(String.format("%s=%s", key, value));
+    });
+    return String.format("%s",filterItems.toString());
+  }
+
 }

--- a/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
+++ b/common/src/main/java/com/spotify/spydra/util/SpydraArgumentUtil.java
@@ -263,7 +263,7 @@ public class SpydraArgumentUtil {
       }
       filterItems.add(String.format("%s=%s", key, value));
     });
-    return String.format("%s",filterItems.toString());
+    return filterItems.toString();
   }
 
 }

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/PoolingSubmitter.java
@@ -119,10 +119,10 @@ public class PoolingSubmitter extends DynamicSubmitter {
       ClusterPlacement placement
   ) throws IOException {
     // Label the pooled cluster with the client id. Unknown client ids all end up in their own pool.
-    SpydraArgument.addOption(arguments.cluster.options, SpydraArgument.OPTION_LABELS,
+    SpydraArgument.addOption(arguments.cluster.options, SpydraArgument.OPTION_CLUSTER_LABELS,
                              POOLED_CLUSTER_CLIENTID_LABEL + "=" + arguments.getClientId());
 
-    SpydraArgument.addOption(arguments.cluster.options, SpydraArgument.OPTION_LABELS,
+    SpydraArgument.addOption(arguments.cluster.options, SpydraArgument.OPTION_CLUSTER_LABELS,
                              SPYDRA_PLACEMENT_TOKEN_LABEL + "=" + placement.token());
 
     String clusterName = generateName(arguments.getClientId(), placement.token());

--- a/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/api/Submitter.java
@@ -59,8 +59,12 @@ public class Submitter {
   }
 
   public boolean executeJob(SpydraArgument arguments) {
+    return executeJob(new ExecutorFactory(), arguments);
+  }
+
+  protected boolean executeJob(ExecutorFactory executorFactory, SpydraArgument arguments) {
     try {
-      Executor executor = new ExecutorFactory().getExecutor(arguments);
+      Executor executor = executorFactory.getExecutor(arguments);
       return executor.submit(arguments);
     } catch (IOException e) {
       LOGGER.error("Failed to submit job", e);

--- a/spydra/src/main/java/com/spotify/spydra/submitter/executor/ExecutorFactory.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/executor/ExecutorFactory.java
@@ -20,7 +20,10 @@
 
 package com.spotify.spydra.submitter.executor;
 
+import com.spotify.spydra.api.DataprocApi;
 import com.spotify.spydra.model.SpydraArgument;
+
+import java.util.function.Supplier;
 
 /**
  * Factory responsible for creating instances of different executors based a
@@ -28,10 +31,20 @@ import com.spotify.spydra.model.SpydraArgument;
  */
 public class ExecutorFactory {
 
+  private final Supplier<DataprocApi> dataprocApiSupplier;
+
+  public ExecutorFactory() {
+    this(DataprocApi::new);
+  }
+
+  public ExecutorFactory(Supplier<DataprocApi> dataprocApiSupplier) {
+    this.dataprocApiSupplier = dataprocApiSupplier;
+  }
+
   public Executor getExecutor(SpydraArgument arguments) {
     switch (arguments.getClusterType()) {
       case DATAPROC:
-        return new DataprocExecutor();
+        return new DataprocExecutor(dataprocApiSupplier.get());
       case ON_PREMISE:
         return new OnPremiseExecutor();
       case NULL:

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliConsts.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/CliConsts.java
@@ -36,4 +36,5 @@ public class CliConsts {
   public static final String USERNAME_OPTION_NAME = "username";
   public static final String LOG_BUCKET_OPTION_NAME = "log-bucket";
   public static final String JOBNAME_OPTION_NAME = "job-name";
+  public static final String JOB_LABELS = "labels";
 }

--- a/spydra/src/main/java/com/spotify/spydra/submitter/runner/SubmissionCliParser.java
+++ b/spydra/src/main/java/com/spotify/spydra/submitter/runner/SubmissionCliParser.java
@@ -59,6 +59,9 @@ public class SubmissionCliParser implements CliParser<SpydraArgument> {
     options.addOption(CliHelper.createSingleOption(
         CliConsts.JOBNAME_OPTION_NAME,
         "job name, used as dataproc job id"));
+    options.addOption(CliHelper.createSingleOption(
+        CliConsts.JOB_LABELS,
+        "job labels, used as dataproc job labels"));
   }
 
   public SpydraArgument parse(String[] args) throws IOException {
@@ -105,6 +108,10 @@ public class SubmissionCliParser implements CliParser<SpydraArgument> {
 
     if (cmdLine.hasOption(SpydraArgument.OPTION_DRYRUN)) {
       spydraArgument.setDryRun(true);
+    }
+
+    if (cmdLine.hasOption(SpydraArgument.OPTION_JOB_LABELS)) {
+      spydraArgument.getSubmit().setLabels(cmdLine.getOptionValue(CliConsts.JOB_LABELS));
     }
 
     List<String> jobArgs = new LinkedList<>(cmdLine.getArgList());


### PR DESCRIPTION
This PR is the implementation of issue #80. 

If any label specified under submit.options.labels, submitter checks if there is any job with those labels that is already done, or in progress. If so, attaches to that job(`dataproc wait job jobId`) otherwise continues as before.