### PR TITLE
Fix GCS connector property name.

### DIFF
--- a/spydra/src/main/resources/dataproc_defaults.json
+++ b/spydra/src/main/resources/dataproc_defaults.json
@@ -7,7 +7,7 @@
       "scopes": "cloud-platform",
       "max-idle": "30m",
       "initialization-actions": "${versioned-init-action-uri}/autoscaler.sh",
-      "properties": "mapred:mapreduce.jobhistory.done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/done,mapred:mapreduce.jobhistory.intermediate-done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/${UUID}/done_intermediate,mapred:mapreduce.jobhistory.move.interval-ms=1000,mapred:mapreduce.output.fileoutputformat.compress=true,mapred:mapreduce.map.output.compress=true,mapred:mapreduce.output.fileoutputformat.compress.type=BLOCK,core:fs.gs.parent.timestamp.update.substrings.includes=gs://${LOG_BUCKET}/history,yarn:yarn.log-aggregation-enable=true,yarn:yarn.nodemanager.remote-app-log-dir=gs://${LOG_BUCKET}/logs/${CLIENT_ID},yarn:yarn.log-aggregation.retain-seconds=-1,core:fs.gs.implicit.directory.repair=false"
+      "properties": "mapred:mapreduce.jobhistory.done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/done,mapred:mapreduce.jobhistory.intermediate-done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/${UUID}/done_intermediate,mapred:mapreduce.jobhistory.move.interval-ms=1000,mapred:mapreduce.output.fileoutputformat.compress=true,mapred:mapreduce.map.output.compress=true,mapred:mapreduce.output.fileoutputformat.compress.type=BLOCK,core:fs.gs.parent.timestamp.update.substrings.includes=gs://${LOG_BUCKET}/history,yarn:yarn.log-aggregation-enable=true,yarn:yarn.nodemanager.remote-app-log-dir=gs://${LOG_BUCKET}/logs/${CLIENT_ID},yarn:yarn.log-aggregation.retain-seconds=-1,core:fs.gs.implicit.dir.repair=false"
     }
   },
   "submit": {

--- a/spydra/src/main/resources/dataproc_defaults.json
+++ b/spydra/src/main/resources/dataproc_defaults.json
@@ -7,7 +7,7 @@
       "scopes": "cloud-platform",
       "max-idle": "30m",
       "initialization-actions": "${versioned-init-action-uri}/autoscaler.sh",
-      "properties": "mapred:mapreduce.jobhistory.done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/done,mapred:mapreduce.jobhistory.intermediate-done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/${UUID}/done_intermediate,mapred:mapreduce.jobhistory.move.interval-ms=1000,mapred:mapreduce.output.fileoutputformat.compress=true,mapred:mapreduce.map.output.compress=true,mapred:mapreduce.output.fileoutputformat.compress.type=BLOCK,core:fs.gs.parent.timestamp.update.substrings.includes=gs://${LOG_BUCKET}/history,yarn:yarn.log-aggregation-enable=true,yarn:yarn.nodemanager.remote-app-log-dir=gs://${LOG_BUCKET}/logs/${CLIENT_ID},yarn:yarn.log-aggregation.retain-seconds=-1,core:fs.gs.implicit.dir.repair=false"
+      "properties": "mapred:mapreduce.jobhistory.done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/done,mapred:mapreduce.jobhistory.intermediate-done-dir=gs://${LOG_BUCKET}/history/${CLIENT_ID}/${UUID}/done_intermediate,mapred:mapreduce.jobhistory.move.interval-ms=1000,mapred:mapreduce.output.fileoutputformat.compress=true,mapred:mapreduce.map.output.compress=true,mapred:mapreduce.output.fileoutputformat.compress.type=BLOCK,core:fs.gs.parent.timestamp.update.substrings.includes=gs://${LOG_BUCKET}/history,yarn:yarn.log-aggregation-enable=true,yarn:yarn.nodemanager.remote-app-log-dir=gs://${LOG_BUCKET}/logs/${CLIENT_ID},yarn:yarn.log-aggregation.retain-seconds=-1,core:fs.gs.implicit.dir.repair.enable=false"
     }
   },
   "submit": {


### PR DESCRIPTION
Change property name from `fs.gs.implicit.directory.repair` to `fs.gs.implicit.dir.repair.enable`.

Valid configuration value could be seen [here](https://github.com/GoogleCloudPlatform/bigdata-interop/blob/9e572ec40f2ec6df1144963a9b5ca4e6052e5b4d/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java#L276:L279).