### PR TITLE
Read from streams in ProcessHelper to avoid deadlock on large output.

### DIFF
--- a/spydra/src/test/java/com/spotify/spydra/api/process/ProcessHelperTest.java
+++ b/spydra/src/test/java/com/spotify/spydra/api/process/ProcessHelperTest.java
@@ -1,0 +1,56 @@
+/*-
+ * -\-\-
+ * Spydra
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.spydra.api.process;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class ProcessHelperTest {
+
+  @Test
+  public void testAllowsForLargeOutputOnStdout() throws IOException {
+    final StringBuilder outputBuilder = new StringBuilder();
+    final boolean success = ProcessHelper.executeForOutput(Arrays.asList(
+        "bash",
+        "-c",
+        "for i in {1..100000}; do echo hello; done"), outputBuilder);
+    assertTrue("Command was not successful: " + outputBuilder.toString(), success);
+    final List<String> words = Arrays.asList(outputBuilder.toString().split("\n"));
+    assertEquals(100000, words.size());
+  }
+
+  @Test
+  public void testAllowsForLargeOutputOnStderr() throws IOException {
+    final StringBuilder outputBuilder = new StringBuilder();
+    final boolean success = ProcessHelper.executeForOutput(Arrays.asList(
+        "bash",
+        "-c",
+        "for i in {1..100000}; do >&2 echo hello; done; false;"), outputBuilder);
+    assertFalse("Command was successful: " + outputBuilder.toString(), success);
+    final List<String> words = Arrays.asList(outputBuilder.toString().split("\n"));
+    assertEquals(100000, words.size());
+  }
+}


### PR DESCRIPTION
Spydra uses a built-in `ProcessHelper` class to shell out to command line tools, like `gcloud`. This helper waits for the subprocess to exit before reading its output, which can lead to deadlock if the process generates more than 64kb<sup>1</sup> of output on `stdout` or `stderr`.

This PR fixes this issue by:
 - reading from both `stdout` and `stderr` of the process while waiting for it to complete
 - buffering the output of both streams into two independent `StringBuilder` objects
 - adding a test for this behaviour (although this test requires the test runner to shell out to `bash`)

---
<sup>1</sup> this is [the default size of the pipe buffer](https://unix.stackexchange.com/questions/11946/how-big-is-the-pipe-buffer) on Linux, although this can vary across systems.