### PR TITLE
Set Ubuntu distro for build task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 jdk:
   - oraclejdk8
 
-dist: bionic
+dist: trusty
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: java
 jdk:
   - oraclejdk8
 
+dist: bionic
+
 cache:
   directories:
     - "$HOME/google-cloud-sdk/"


### PR DESCRIPTION
The CI build currently fails during installation of Oracle JDK, see details below:

```
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2020-06-02
Expected feature release number in range of 9 to 16, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
Your build has been stopped.
```

This is likely related to the Ubuntu distro used in the build task, see discussions [here](https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/5). The PR sets the distro to Bionic