### PR TITLE
Skip integration tests when GOOGLE_APPLICATION_CREDENTIALS is not set

### DIFF
--- a/spydra/src/test/java/com/spotify/spydra/LifecycleIT.java
+++ b/spydra/src/test/java/com/spotify/spydra/LifecycleIT.java
@@ -65,7 +65,7 @@ public class LifecycleIT {
     // service in gcp if we use the default account
     Assume.assumeTrue("Skipping lifecycle test, not running on gce and "
                       + "GOOGLE_APPLICATION_CREDENTIALS not set",
-        hasApplicationJsonOrRunningOnGce());
+        hasApplicationJson());
     SpydraArgument testArgs = SpydraArgumentUtil.loadArguments("integration-test-config.json");
     SpydraArgument arguments = SpydraArgumentUtil
         .dataprocConfiguration(CLIENT_ID, testArgs.getLogBucket(), testArgs.getRegion());
@@ -97,9 +97,8 @@ public class LifecycleIT {
     assertEquals(0, getFileCount(intermediateUri));
   }
 
-  private boolean hasApplicationJsonOrRunningOnGce() {
-    return new GcpUtils().getJsonCredentialsPath().isPresent()
-           || GceHelper.runningOnComputeEngine();
+  private boolean hasApplicationJson() {
+    return new GcpUtils().getJsonCredentialsPath().isPresent();
   }
 
   private boolean isClusterCollected(SpydraArgument arguments)


### PR DESCRIPTION
The check that determines if integration tests should be skipped involves a check on whether it's running on compute engine and if `GOOGLE_APPLICATION_CREDENTIALS` is set. The first check succeeds with the result that integration tests are run when `GOOGLE_APPLICATION_CREDENTIALS` is not set, resulting in the failure:

```
ERROR [main] (GcloudExecutor.java:77) - ERROR: (gcloud.beta.dataproc.clusters.create) You do not currently have an active account selected.
Please run:
  $ gcloud auth login
to obtain new credentials, or if you have already logged in with a
different account:
  $ gcloud config set account ACCOUNT
to select an already authenticated account to use.
```

This change skips integration tests when `GOOGLE_APPLICATION_CREDENTIALS` is missing. See last [successful build ](https://travis-ci.org/github/spotify/spydra/builds/402141807)