### PR TITLE
Set explicitly commons-cli dependency

### DIFF
--- a/spydra/pom.xml
+++ b/spydra/pom.xml
@@ -31,6 +31,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
     </dependency>


### PR DESCRIPTION
This puts commons-cli with version defined by the spydra-parent as transitive dependency.

When letting maven resolve for sydra, common-cli 1.2 was taken from hadoop transitive dependency.